### PR TITLE
[ISSUE 14] Load XML config with default name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.4.1 (2015-11-04)
+
+    Documentation:
+
+        - add -c documentation in the readme
+  
+    Features:
+  
+        - it's now possible to Load XML config with default name

--- a/README.md
+++ b/README.md
@@ -40,11 +40,19 @@ This command will launch all the tests in all your configured testsuites.
 ###Optional parameters
 If your `phpunit.xml.dist` file is not in the default base dir, you can specify it by:
 
-`--configuration=relPath/to/phpunit.xml.dist`
+`vendor/bin/paraunit run --configuration=relPath/to/phpunit.xml.dist`
+
+or with the short version:
+
+`vendor/bin/paraunit run -c=relPath/to/phpunit.xml.dist`
+
+Also it's possible to provide only a directory, in such case paraunit will look for the 'phpunit.xml.dist':
+
+`vendor/bin/paraunit run -c=relPath/to/xml/file/`
 
 You can run a single test suite using:
 
-`--testsuite=testSuiteName`
+`vendor/bin/paraunit run --testsuite=testSuiteName`
 
 If you have problem running the tests, or the execution stops before the results are printed out, you can launch paraunit in debug mode, with:
 

--- a/src/Paraunit/Command/ParallelCommand.php
+++ b/src/Paraunit/Command/ParallelCommand.php
@@ -2,6 +2,7 @@
 
 namespace Paraunit\Command;
 
+use Paraunit\Configuration\PHPUnitConfigFile;
 use Paraunit\Filter\Filter;
 use Paraunit\Runner\Runner;
 use Symfony\Component\Console\Command\Command;
@@ -37,7 +38,7 @@ class ParallelCommand extends Command
     {
         $this
             ->setName('run')
-            ->addOption('configuration', null, InputOption::VALUE_REQUIRED, 'The PHPUnit XML config file', 'phpunit.xml.dist')
+            ->addOption('configuration', 'c', InputOption::VALUE_REQUIRED, 'The PHPUnit XML config file', PHPUnitConfigFile::DEFAULT_FILE_NAME)
             ->addOption('testsuite', null, InputOption::VALUE_REQUIRED, 'Choice a specific testsuite from your XML config file')
             ->addOption('debug', null, InputOption::VALUE_NONE, 'Print verbose debug output');
     }
@@ -58,7 +59,8 @@ class ParallelCommand extends Command
             $testsuite = $input->getOption('testsuite');
         }
 
-        $config = $input->getOption('configuration');
+        $configOption = $input->getOption('configuration');
+        $config = new PHPUnitConfigFile($configOption);
 
         $testArray = $this->filter->filterTestFiles($config, $testsuite);
 

--- a/src/Paraunit/Configuration/PHPUnitConfigFile.php
+++ b/src/Paraunit/Configuration/PHPUnitConfigFile.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Paraunit\Configuration;
+
+class PHPUnitConfigFile
+{
+    const DEFAULT_FILE_NAME = 'phpunit.xml.dist';
+
+    /** @var string */
+    private $configFile;
+
+    /**
+     * @param string $inputPathOrFileName
+     */
+    public function __construct($inputPathOrFileName)
+    {
+        $inputPathOrFileName = realpath($inputPathOrFileName);
+
+        if (false === $inputPathOrFileName) {
+            throw new \InvalidArgumentException('Config path/file provided is not valid (does it exist?)');
+        }
+
+        $configFile = is_dir($inputPathOrFileName)
+            ? $inputPathOrFileName . DIRECTORY_SEPARATOR . self::DEFAULT_FILE_NAME
+            : $inputPathOrFileName;
+
+        if ( ! is_file($configFile) || ! is_readable($configFile)) {
+            throw new \InvalidArgumentException('Config file ' . $configFile . ' does not exist or is not readable');
+        }
+
+        $this->configFile = $configFile;
+    }
+
+    /**
+     * Get the full path for this configuration file
+     * @return string
+     */
+    public function getFileFullPath()
+    {
+        return $this->configFile;
+    }
+
+    /**
+     * Get the directory which contains this configuration file
+     * @return string
+     */
+    public function getDirectory()
+    {
+        return dirname($this->configFile);
+    }
+}

--- a/src/Paraunit/Filter/Filter.php
+++ b/src/Paraunit/Filter/Filter.php
@@ -2,6 +2,7 @@
 
 namespace Paraunit\Filter;
 
+use Paraunit\Configuration\PHPUnitConfigFile;
 use Paraunit\Proxy\PHPUnit_Util_XML_Proxy;
 
 /**
@@ -30,17 +31,17 @@ class Filter
     }
 
     /**
-     * @param string $configFile
+     * @param PHPUnitConfigFile $configFile
      * @param string | null $testSuiteFilter
      *
      * @return array
      */
-    public function filterTestFiles($configFile, $testSuiteFilter = null)
+    public function filterTestFiles(PHPUnitConfigFile $configFile, $testSuiteFilter = null)
     {
         $aggregatedFiles = array();
-        $this->relativePath = realpath(dirname($configFile)) . DIRECTORY_SEPARATOR;
+        $this->relativePath = $configFile->getDirectory() . DIRECTORY_SEPARATOR;
 
-        $document = $this->utilXml->loadFile($configFile, false, true, true);
+        $document = $this->utilXml->loadFile($configFile->getFileFullPath(), false, true, true);
         $xpath = new \DOMXPath($document);
 
         /** @var \DOMNode $testSuiteNode */

--- a/src/Paraunit/Runner/Runner.php
+++ b/src/Paraunit/Runner/Runner.php
@@ -2,6 +2,7 @@
 
 namespace Paraunit\Runner;
 
+use Paraunit\Configuration\PHPUnitConfigFile;
 use Paraunit\Printer\DebugPrinter;
 use Paraunit\Printer\SharkPrinter;
 use Paraunit\Process\ParaunitProcessAbstract;
@@ -37,7 +38,7 @@ class Runner
     /** @var ParaunitProcessAbstract[] */
     protected $processRunning;
 
-    /** @var  string */
+    /** @var  PHPUnitConfigFile */
     protected $phpunitConfigFile;
 
     /** @var  string */
@@ -73,11 +74,11 @@ class Runner
     /**
      * @param                 $files
      * @param OutputInterface $outputInterface
-     * @param $phpunitConfigFile
+     * @param PHPUnitConfigFile $phpunitConfigFile
      * @param bool $debug
      * @return int
      */
-    public function run($files, OutputInterface $outputInterface, $phpunitConfigFile, $debug = false)
+    public function run($files, OutputInterface $outputInterface, PHPUnitConfigFile $phpunitConfigFile, $debug = false)
     {
         $this->phpunitConfigFile = $phpunitConfigFile;
 
@@ -159,11 +160,9 @@ class Runner
      */
     protected function createProcess($fileName)
     {
-        $configurationFile = getcwd().'/'.$this->phpunitConfigFile;
-
         $command =
             $this->phpunitBin.
-            ' -c '.$configurationFile.' '.
+            ' -c '.$this->phpunitConfigFile->getFileFullPath().' '.
             ' --colors=never '.
             $fileName.
             ' 2>&1';

--- a/src/Paraunit/Tests/Functional/RunnerTest.php
+++ b/src/Paraunit/Tests/Functional/RunnerTest.php
@@ -2,6 +2,7 @@
 
 namespace Paraunit\Tests\Functional;
 
+use Paraunit\Configuration\PHPUnitConfigFile;
 use Paraunit\Runner\Runner;
 use Paraunit\Tests\Stub\ConsoleOutputStub;
 
@@ -32,7 +33,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             'src/Paraunit/Tests/Stub/ThreeGreenTestStub.php',
         );
 
-        $this->assertEquals(0, $runner->run($fileArray, $outputInterface, 'phpunit.xml.dist'));
+        $this->assertEquals(0, $runner->run($fileArray, $outputInterface, new PHPUnitConfigFile('')));
 
         $dumpster = array(); // PHP 5.3 needs this crap
         $greenCount = preg_match_all("/<ok>.<\/ok>/", $outputInterface->getOutput(), $dumpster);
@@ -51,7 +52,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             'src/Paraunit/Tests/Stub/EntityManagerClosedTestStub.php',
         );
 
-        $this->assertNotEquals(0, $runner->run($fileArray, $outputInterface, 'phpunit.xml.dist'));
+        $this->assertNotEquals(0, $runner->run($fileArray, $outputInterface, new PHPUnitConfigFile('')));
 
         $retryCount = array();
         preg_match_all("/<ok>A<\/ok>/", $outputInterface->getOutput(), $retryCount);
@@ -72,7 +73,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
             'src/Paraunit/Tests/Stub/DeadLockTestStub.php',
         );
 
-        $this->assertNotEquals(0, $runner->run($fileArray, $outputInterface, 'phpunit.xml.dist'));
+        $this->assertNotEquals(0, $runner->run($fileArray, $outputInterface, new PHPUnitConfigFile('')));
 
         $retryCount = array();
         preg_match_all("/<ok>A<\/ok>/", $outputInterface->getOutput(), $retryCount);
@@ -99,7 +100,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEquals(
             0,
-            $runner->run($fileArray, $outputInterface, 'phpunit.xml.dist'),
+            $runner->run($fileArray, $outputInterface, new PHPUnitConfigFile('')),
             'Exit code should not be 0'
         );
 

--- a/src/Paraunit/Tests/Stub/StubbedXMLConfigs/phpunit.xml.dist
+++ b/src/Paraunit/Tests/Stub/StubbedXMLConfigs/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+        >
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite>
+            <directory suffix="TestSuffix.php">./only/selected/test/suite/</directory>
+        </testsuite>
+        <testsuite>
+            <directory>./other/test/suite/</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/src/Paraunit/Tests/Unit/Configuration/PHPUnitConfigFileTest.php
+++ b/src/Paraunit/Tests/Unit/Configuration/PHPUnitConfigFileTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Paraunit\Tests\Unit\Configuration;
+
+use Paraunit\Configuration\PHPUnitConfigFile;
+
+class PHPUnitConfigFileTest extends \PHPUnit_Framework_TestCase
+{
+    private $previousCWD;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->previousCWD = getcwd();
+
+        $stubPath = realpath(__DIR__ . '/../../Stub');
+        chdir($stubPath);
+    }
+
+    protected function tearDown()
+    {
+        chdir($this->previousCWD);
+        $this->previousCWD = null;
+
+        parent::tearDown();
+    }
+
+    public function testRelativeDirectoryDoesUseDefaultFileName()
+    {
+        $dir = 'StubbedXMLConfigs';
+
+        $config = new PHPUnitConfigFile($dir);
+
+        $filePath = $config->getFileFullPath();
+        $this->assertStringEndsWith(PHPUnitConfigFile::DEFAULT_FILE_NAME, $filePath);
+
+        $directoryPath = $config->getDirectory();
+        $this->assertStringEndsWith($dir, $directoryPath);
+    }
+
+    public function testRelativeFilenameDoesNotUseDefaultFileName()
+    {
+        $file = 'StubbedXMLConfigs/stubbed_for_filter_test.xml';
+
+        $config = new PHPUnitConfigFile($file);
+
+        $filePath = $config->getFileFullPath();
+
+        $this->assertStringEndsNotWith(PHPUnitConfigFile::DEFAULT_FILE_NAME, $filePath);
+    }
+
+    public function testRelativeDirectoryAndDefaultFileDoesNotExistThrowException()
+    {
+        $dir = 'PHPUnitOutput';
+
+        $this->setExpectedException('InvalidArgumentException', PHPUnitConfigFile::DEFAULT_FILE_NAME . ' does not exist');
+
+        $config = new PHPUnitConfigFile($dir);
+    }
+
+    public function testInvalidDirectoryProvidedThrowException()
+    {
+        $dir = 'foobar';
+
+        $this->setExpectedException('InvalidArgumentException', 'Config path/file provided is not valid');
+
+        $config = new PHPUnitConfigFile($dir);
+    }
+}

--- a/src/Paraunit/Tests/Unit/Filter/FilterTest.php
+++ b/src/Paraunit/Tests/Unit/Filter/FilterTest.php
@@ -2,6 +2,7 @@
 
 namespace Paraunit\Tests\Unit\Filter;
 
+use Paraunit\Configuration\PHPUnitConfigFile;
 use Paraunit\Filter\Filter;
 
 class FilterTest extends \PHPUnit_Framework_TestCase
@@ -21,6 +22,8 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     public function testFilterTestFiles_gets_only_requested_testsuite()
     {
         $configFile = $this->absoluteConfigBaseDir . 'stubbed_for_filter_test.xml';
+        $configFilePhpUnit = new PHPUnitConfigFile($configFile);
+
         $testSuiteName = 'test_only_requested_testsuite';
 
         $utilXml = $this->prophesize(static::PHPUNIT_UTIL_XML_PROXY_CLASS);
@@ -41,7 +44,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter = new Filter($utilXml->reveal(), $fileIterator->reveal());
 
-        $result = $filter->filterTestFiles($configFile, $testSuiteName);
+        $result = $filter->filterTestFiles($configFilePhpUnit, $testSuiteName);
 
         $this->assertCount(1, $result);
         $this->assertEquals(array($file1), $result);
@@ -50,6 +53,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     public function testFilterTestFiles_supports_suffix_attribute()
     {
         $configFile = $this->absoluteConfigBaseDir . 'stubbed_for_suffix_test.xml';
+        $configFilePhpUnit = new PHPUnitConfigFile($configFile);
 
         $utilXml = $this->prophesize(static::PHPUNIT_UTIL_XML_PROXY_CLASS);
         $utilXml->loadFile($configFile, false, true, true)
@@ -69,13 +73,14 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter = new Filter($utilXml->reveal(), $fileIterator->reveal());
 
-        $result = $filter->filterTestFiles($configFile);
+        $result = $filter->filterTestFiles($configFilePhpUnit);
         $this->assertEquals(array($file1, $file2), $result);
     }
 
     public function testFilterTestFiles_supports_prefix_attribute()
     {
         $configFile = $this->absoluteConfigBaseDir . 'stubbed_for_prefix_test.xml';
+        $configFilePhpUnit = new PHPUnitConfigFile($configFile);
 
         $utilXml = $this->prophesize(static::PHPUNIT_UTIL_XML_PROXY_CLASS);
         $utilXml->loadFile($configFile, false, true, true)
@@ -95,13 +100,14 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter = new Filter($utilXml->reveal(), $fileIterator->reveal());
 
-        $result = $filter->filterTestFiles($configFile);
+        $result = $filter->filterTestFiles($configFilePhpUnit);
         $this->assertEquals(array($file1, $file2), $result);
     }
 
     public function testFilterTestFiles_supports_exclude_nodes()
     {
         $configFile = $this->absoluteConfigBaseDir . 'stubbed_for_node_exclude.xml';
+        $configFilePhpUnit = new PHPUnitConfigFile($configFile);
 
         $utilXml = $this->prophesize(static::PHPUNIT_UTIL_XML_PROXY_CLASS);
         $utilXml->loadFile($configFile, false, true, true)
@@ -131,13 +137,14 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter = new Filter($utilXml->reveal(), $fileIterator->reveal());
 
-        $result = $filter->filterTestFiles($configFile);
+        $result = $filter->filterTestFiles($configFilePhpUnit);
         $this->assertEquals(array($file1, $file2), $result);
     }
 
     public function testFilterTestFiles_avoids_duplicate_runs()
     {
         $configFile = $this->absoluteConfigBaseDir . 'stubbed_for_filter_test.xml';
+        $configFilePhpUnit = new PHPUnitConfigFile($configFile);
 
         $utilXml = $this->prophesize(static::PHPUNIT_UTIL_XML_PROXY_CLASS);
         $utilXml->loadFile($configFile, false, true, true)
@@ -156,7 +163,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter = new Filter($utilXml->reveal(), $fileIterator->reveal());
 
-        $result = $filter->filterTestFiles($configFile);
+        $result = $filter->filterTestFiles($configFilePhpUnit);
         $this->assertCount(1, $result);
         $this->assertEquals(array($file), $result);
     }
@@ -164,6 +171,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
     public function testFilterTestFiles_supports_file_nodes()
     {
         $configFile = $this->absoluteConfigBaseDir . 'stubbed_for_node_file.xml';
+        $configFilePhpUnit = new PHPUnitConfigFile($configFile);
 
         $utilXml = $this->prophesize(static::PHPUNIT_UTIL_XML_PROXY_CLASS);
         $utilXml->loadFile($configFile, false, true, true)
@@ -183,7 +191,7 @@ class FilterTest extends \PHPUnit_Framework_TestCase
 
         $filter = new Filter($utilXml->reveal(), $fileIterator->reveal());
 
-        $result = $filter->filterTestFiles($configFile);
+        $result = $filter->filterTestFiles($configFilePhpUnit);
         $this->assertEquals(
             array(
                 $file1,


### PR DESCRIPTION
This commit fixes issue https://github.com/facile-it/paraunit/issues/14
This PR also adds the shortcut `-c` to the `--configuration` option.