### PR TITLE
new dockerfile and build script for 5.6 and 7

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -2,6 +2,15 @@
 
 All notable changes of the Paraunit 0.x release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [Unreleased]
+### Added
+* A new approach for dockerfiles, now they will be based on the standard docker PHP library. This will allow for a
+faster image build, cleaner dockerfiles and a more precise PHP version targering, including:
+  * "dockerfile-php-5.6" with the related  "setup-php-5.6.sh" script that will allow to build a container
+  with PHP 5.6 image
+  * "dockerfile-php-7" with the related  "setup-php-7.sh" script that will allow to build a container
+      with PHP 7 image
+
 ## [0.6] - 2016-03-20
 
 ### Changed

--- a/docker/dockerfile-php-5.6
+++ b/docker/dockerfile-php-5.6
@@ -1,0 +1,49 @@
+FROM php:5.6-cli
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt-get install -y apt-utils curl zsh ssh git supervisor sudo git less vim-tiny apg nano
+
+RUN pecl install xdebug  && \
+    echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20131226/xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini && \
+    echo "date.timezone = $TZ" > /usr/local/etc/php/conf.d/timezone.ini
+
+COPY config/sudoers /etc/sudoers
+COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+RUN useradd -ms /bin/bash paraunit
+RUN usermod -aG sudo paraunit
+USER paraunit
+
+WORKDIR /home/paraunit/projects
+
+#COMPOSER
+RUN sudo curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
+
+#CS FIX
+RUN sudo curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
+RUN sudo chmod a+x php-cs-fixer
+RUN sudo mv php-cs-fixer /usr/local/bin/php-cs-fixer
+
+#Zsh minimal installation
+RUN git clone --depth=1 git://github.com/robbyrussell/oh-my-zsh.git  ~/.oh-my-zsh
+RUN sudo chsh -s /bin/zsh
+ADD config/.zshrc /root/
+ADD config/.zshrc /home/paraunit/
+ENV TERM xterm-256color
+
+#----- BEGIN Enable sigsegv extension
+WORKDIR /tmp/
+RUN git clone https://github.com/facile-it/paraunit.git
+WORKDIR /tmp/paraunit/.travis/sigsegv-extension
+RUN phpize
+RUN ./configure --enable-sigsegv
+RUN make -j
+COPY sigsegv/sigsegv.ini /usr/local/etc/php/conf.d/
+#----- END Enable sigsegv extension
+
+WORKDIR /home/paraunit/projects
+VOLUME ["/home/paraunit/projects"]
+
+CMD sudo /usr/bin/supervisord

--- a/docker/dockerfile-php-7
+++ b/docker/dockerfile-php-7
@@ -29,6 +29,16 @@ ADD config/.zshrc /root/
 ADD config/.zshrc /home/paraunit/
 ENV TERM xterm-256color
 
+#----- BEGIN Enable sigsegv extension
+WORKDIR /tmp/
+RUN git clone https://github.com/facile-it/paraunit.git
+WORKDIR /tmp/paraunit/.travis/sigsegv-extension
+RUN phpize
+RUN ./configure --enable-sigsegv
+RUN make -j
+COPY sigsegv/sigsegv.ini /usr/local/etc/php/conf.d/
+#----- END Enable sigsegv extension
+
 WORKDIR /home/paraunit/projects
 VOLUME ["/home/paraunit/projects"]
 

--- a/docker/dockerfile-php-7
+++ b/docker/dockerfile-php-7
@@ -1,0 +1,35 @@
+FROM php:7-cli
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt-get install -y apt-utils curl zsh ssh git supervisor sudo git less vim-tiny apg nano
+
+COPY config/sudoers /etc/sudoers
+COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+RUN useradd -ms /bin/bash paraunit
+RUN usermod -aG sudo paraunit
+USER paraunit
+
+WORKDIR /home/paraunit/projects
+
+#COMPOSER
+RUN sudo curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
+
+#CS FIX
+RUN sudo curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
+RUN sudo chmod a+x php-cs-fixer
+RUN sudo mv php-cs-fixer /usr/local/bin/php-cs-fixer
+
+#Zsh minimal installation
+RUN git clone --depth=1 git://github.com/robbyrussell/oh-my-zsh.git  ~/.oh-my-zsh
+RUN sudo chsh -s /bin/zsh
+ADD config/.zshrc /root/
+ADD config/.zshrc /home/paraunit/
+ENV TERM xterm-256color
+
+WORKDIR /home/paraunit/projects
+VOLUME ["/home/paraunit/projects"]
+
+CMD sudo /usr/bin/supervisord

--- a/docker/setup-php-5.6.sh
+++ b/docker/setup-php-5.6.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+docker build -f $DIR/dockerfile-php-5.6 -t paraunit_image_php_5_6 $DIR
+
+docker rm -f paraunit_container_php_5_6
+docker run -d -v $DIR/../:/home/paraunit/projects --name paraunit_container_php_5_6 -ti paraunit_image_php_5_6 bash
+
+sleep 1
+
+docker exec -ti -u paraunit paraunit_container_php_5_6 zsh

--- a/docker/setup-php-7.sh
+++ b/docker/setup-php-7.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+docker build -f $DIR/dockerfile-php-7 -t paraunit_image_php_7 $DIR
+
+docker rm -f paraunit_container_php_7
+docker run -d -v $DIR/../:/home/paraunit/projects --name paraunit_container_php_7 -ti paraunit_image_php_7 bash
+
+sleep 1
+
+docker exec -ti -u paraunit paraunit_container_php_7 zsh


### PR DESCRIPTION
Opening the PR for review.

Mostly some cleanup work but now we'll be able to run tests inside the php-7 container and the php-5.6 one.

I've kept the original Dockerfile separated for now but it should be declared deprecated and maybe removed in the next release.

I've removed xdebug and the segfault extension from the php-7 container as for now they don't apply.