### PR TITLE
sys_get_temp_dir() for temporary directory

### DIFF
--- a/src/Paraunit/File/TempDirectory.php
+++ b/src/Paraunit/File/TempDirectory.php
@@ -8,12 +8,13 @@ namespace Paraunit\File;
  */
 class TempDirectory
 {
+    /** @var array */
     private static $tempDirs = array(
         '/dev/shm',
         '/temp',
     );
 
-    /** @var  string */
+    /** @var string */
     private $timestamp;
 
     /**
@@ -42,7 +43,11 @@ class TempDirectory
      */
     public static function getTempBaseDir()
     {
-        foreach (self::$tempDirs as $directory) {
+        $dirs = self::$tempDirs;
+        // Fallback to sys temp dir
+        $dirs[] = sys_get_temp_dir();
+
+        foreach ($dirs as $directory) {
             if (file_exists($directory)) {
                 $baseDir = $directory . DIRECTORY_SEPARATOR . 'paraunit';
                 self::mkdirIfNotExists($baseDir);
@@ -59,8 +64,14 @@ class TempDirectory
      */
     private static function mkdirIfNotExists($path)
     {
-        if (! file_exists($path)) {
-            mkdir($path);
+        if (file_exists($path)) {
+            return;
+        }
+
+        if (!mkdir($path) && !is_dir($path)) {
+            throw new \RuntimeException(
+                sprintf('Unable to create temporary directory \'%s\'.', $path)
+            );
         }
     }
 }

--- a/src/Paraunit/File/TempDirectory.php
+++ b/src/Paraunit/File/TempDirectory.php
@@ -8,10 +8,9 @@ namespace Paraunit\File;
  */
 class TempDirectory
 {
-    /** @var array */
+    /** @var string[] */
     private static $tempDirs = array(
         '/dev/shm',
-        '/temp',
     );
 
     /** @var string */
@@ -40,6 +39,8 @@ class TempDirectory
 
     /**
      * @return string
+     *
+     * @throws \RuntimeException
      */
     public static function getTempBaseDir()
     {
@@ -50,9 +51,14 @@ class TempDirectory
         foreach ($dirs as $directory) {
             if (file_exists($directory)) {
                 $baseDir = $directory . DIRECTORY_SEPARATOR . 'paraunit';
-                self::mkdirIfNotExists($baseDir);
 
-                return $baseDir;
+                try {
+                    self::mkdirIfNotExists($baseDir);
+
+                    return $baseDir;
+                } catch (\RuntimeException $e) {
+                    // ignore and try next dir
+                }
             }
         }
 
@@ -61,6 +67,8 @@ class TempDirectory
 
     /**
      * @param string $path
+     *
+     * @throws \RuntimeException
      */
     private static function mkdirIfNotExists($path)
     {


### PR DESCRIPTION
- Fallback to `sys_get_temp_dir()` for temporary directory. In this way it's always possibile to execute tests in every environment.
- Added check on creating subdirectories