### PR TITLE
Add missing ObjectProphecy::reveal() calls

### DIFF
--- a/tests/Unit/Command/CoverageCommandTest.php
+++ b/tests/Unit/Command/CoverageCommandTest.php
@@ -40,7 +40,7 @@ class CoverageCommandTest extends BaseUnitTestCase
         $configuration = $this->prophesize(CoverageConfiguration::class);
         $configuration->buildContainer(Argument::cetera())
             ->shouldBeCalled()
-            ->willReturn($container);
+            ->willReturn($container->reveal());
 
         $command = new CoverageCommand($configuration->reveal());
         $application = new Application();

--- a/tests/Unit/Command/ParallelCommandTest.php
+++ b/tests/Unit/Command/ParallelCommandTest.php
@@ -37,7 +37,7 @@ class ParallelCommandTest extends BaseUnitTestCase
         $configuration = $this->prophesize(ParallelConfiguration::class);
         $configuration->buildContainer(Argument::cetera())
             ->shouldBeCalled()
-            ->willReturn($container);
+            ->willReturn($container->reveal());
 
         $command = new ParallelCommand($configuration->reveal());
         $application = new Application();


### PR DESCRIPTION
The tests were passing because Prophecy automatically calls reveal() on prophecies passed as return values of method prophecies. Still, this is an unexpected behavior and it's safer not to rely on it.