### PR TITLE
Handle deprecation failures

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+ * Add support for deprecation warnings found by `symfony/phpunit-bridge`: failures and tests output are now reported
+
 ### Changed
  * Start suggesting `dama/doctrine-test-bundle` instead of `facile-it/paraunit-testcase`, since it has been abandoned.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get update \
     less \
     vim-tiny \
     nano \
- ## PHP-EXT
     libzip-dev \
     && docker-php-ext-install -j5 zip mbstring pcntl \
     && apt-get clean

--- a/src/Paraunit/Parser/DeprecationParser.php
+++ b/src/Paraunit/Parser/DeprecationParser.php
@@ -2,13 +2,14 @@
 
 namespace Paraunit\Parser;
 
-use Paraunit\Parser\JSON\ParserChainElementInterface;
+use Paraunit\Lifecycle\ProcessEvent;
 use Paraunit\Process\AbstractParaunitProcess;
 use Paraunit\TestResult\Interfaces\TestResultContainerInterface;
 use Paraunit\TestResult\Interfaces\TestResultHandlerInterface;
 use Paraunit\TestResult\TestResultWithMessage;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class DeprecationParser implements ParserChainElementInterface
+class DeprecationParser implements EventSubscriberInterface
 {
     /** @var TestResultHandlerInterface */
     private $testResultContainer;
@@ -22,8 +23,17 @@ class DeprecationParser implements ParserChainElementInterface
         $this->testResultContainer = $testResultContainer;
     }
 
-    public function handleLogItem(AbstractParaunitProcess $process, \stdClass $logItem)
+    public static function getSubscribedEvents(): array
     {
+        return [
+            ProcessEvent::PROCESS_PARSING_COMPLETED => 'handleDeprecations',
+        ];
+    }
+
+    public function handleDeprecations(ProcessEvent $event)
+    {
+        $process = $event->getProcess();
+
         if ($process->getExitCode() === 0) {
             return;
         }

--- a/src/Paraunit/Printer/FinalPrinter.php
+++ b/src/Paraunit/Printer/FinalPrinter.php
@@ -5,7 +5,7 @@ namespace Paraunit\Printer;
 
 use Paraunit\Lifecycle\EngineEvent;
 use Paraunit\Lifecycle\ProcessEvent;
-use Paraunit\TestResult\TestResultContainer;
+use Paraunit\TestResult\Interfaces\TestResultContainerInterface;
 use Paraunit\TestResult\TestResultList;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -87,7 +87,7 @@ class FinalPrinter extends AbstractFinalPrinter implements EventSubscriberInterf
     {
         $testsCount = 0;
         foreach ($this->testResultList->getTestResultContainers() as $container) {
-            if ($container instanceof TestResultContainer) {
+            if ($container instanceof TestResultContainerInterface) {
                 $testsCount += $container->countTestResults();
             }
         }

--- a/src/Paraunit/Resources/config/parser.yml
+++ b/src/Paraunit/Resources/config/parser.yml
@@ -9,7 +9,6 @@ services:
       - "@event_dispatcher"
     calls:
       - ["addParser", ["@paraunit.parser.test_start_parser"]]
-      - ["addParser", ["@paraunit.parser.deprecation_parser"]]
       - ["addParser", ["@paraunit.parser.pass_parser"]]
       - ["addParser", ["@paraunit.parser.retry_parser"]]
       - ["addParser", ["@paraunit.parser.incomplete_parser"]]

--- a/src/Paraunit/Resources/config/parser.yml
+++ b/src/Paraunit/Resources/config/parser.yml
@@ -9,6 +9,7 @@ services:
       - "@event_dispatcher"
     calls:
       - ["addParser", ["@paraunit.parser.test_start_parser"]]
+      - ["addParser", ["@paraunit.parser.deprecation_parser"]]
       - ["addParser", ["@paraunit.parser.pass_parser"]]
       - ["addParser", ["@paraunit.parser.retry_parser"]]
       - ["addParser", ["@paraunit.parser.incomplete_parser"]]
@@ -47,6 +48,11 @@ services:
       - "@paraunit.test_result.test_result_factory"
       - "@paraunit.test_result.failure_container"
       - "fail"
+
+  paraunit.parser.deprecation_parser:
+    class: Paraunit\Parser\DeprecationParser
+    arguments:
+      - "@paraunit.test_result.deprecation_container"
 
   paraunit.parser.warning_parser:
     class: Paraunit\Parser\JSON\GenericParser

--- a/src/Paraunit/Resources/config/test_result.yml
+++ b/src/Paraunit/Resources/config/test_result.yml
@@ -10,6 +10,7 @@ services:
       - ["addContainer", ["@paraunit.test_result.coverage_failure_container"]]
       - ["addContainer", ["@paraunit.test_result.error_container"]]
       - ["addContainer", ["@paraunit.test_result.failure_container"]]
+      - ["addContainer", ["@paraunit.test_result.deprecation_container"]]
       - ["addContainer", ["@paraunit.test_result.warning_container"]]
       - ["addContainer", ["@paraunit.test_result.no_test_executed_container"]]
       - ["addContainer", ["@paraunit.test_result.risky_container"]]

--- a/src/Paraunit/Resources/config/test_result_container.yml
+++ b/src/Paraunit/Resources/config/test_result_container.yml
@@ -39,6 +39,11 @@ services:
     arguments:
       - "@paraunit.test_result.warning_test_result_format"
 
+  paraunit.test_result.deprecation_container:
+    class: Paraunit\TestResult\TestResultContainer
+    arguments:
+      - "@paraunit.test_result.deprecation_result_format"
+
   paraunit.test_result.failure_container:
     class: Paraunit\TestResult\TestResultContainer
     arguments:

--- a/src/Paraunit/Resources/config/test_result_format.yml
+++ b/src/Paraunit/Resources/config/test_result_format.yml
@@ -36,6 +36,12 @@ services:
       - "error"
       - "coverage not fetched"
 
+  paraunit.test_result.deprecation_result_format:
+    class: Paraunit\TestResult\TestResultFormat
+    arguments:
+      - "fail"
+      - "deprecation warnings"
+
   paraunit.test_result.error_test_result_format:
     class: Paraunit\TestResult\TestResultWithSymbolFormat
     arguments:

--- a/src/Paraunit/TestResult/TestResultContainer.php
+++ b/src/Paraunit/TestResult/TestResultContainer.php
@@ -80,6 +80,10 @@ class TestResultContainer implements TestResultContainerInterface, TestResultHan
 
     public function countTestResults(): int
     {
+        if (! $this->testResultFormat instanceof TestResultWithSymbolFormat) {
+            return 0;
+        }
+
         return count($this->testResults);
     }
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -37,6 +37,11 @@ class BaseTestCase extends TestCase
         return $this->getStubPath() . 'phpunit_for_stubs.xml';
     }
 
+    protected function getConfigForDeprecationListener(): string
+    {
+        return $this->getStubPath() . 'phpunit_with_deprecations.xml';
+    }
+
     protected function getStubPath(): string
     {
         return realpath(__DIR__ . DIRECTORY_SEPARATOR . 'Stub') . DIRECTORY_SEPARATOR;

--- a/tests/Functional/Command/ParallelCommandTest.php
+++ b/tests/Functional/Command/ParallelCommandTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Tests\BaseTestCase;
 use Tests\Stub\MissingProviderTestStub;
 use Tests\Stub\MySQLDeadLockTestStub;
+use Tests\Stub\RaisingDeprecationTestStub;
 use Tests\Stub\RaisingNoticeTestStub;
 
 /**
@@ -165,6 +166,7 @@ class ParallelCommandTest extends BaseTestCase
         $this->assertNotEquals(0, $exitCode);
         $this->assertContains('Executed: 1 test classes, 1 tests (0 retried)', $output, 'Precondition failed');
         $this->assertContains('1 files with DEPRECATION WARNINGS:', $output);
-        $this->assertContains('deprecation triggered by RaisingDeprecationTestStub::testDeprecation', $output);
+        $this->assertContains(RaisingDeprecationTestStub::DEPRECATION_MESSAGE, $output);
+        $this->assertContains('RaisingDeprecationTestStub::testDeprecation', $output);
     }
 }

--- a/tests/Functional/Command/ParallelCommandTest.php
+++ b/tests/Functional/Command/ParallelCommandTest.php
@@ -86,7 +86,7 @@ class ParallelCommandTest extends BaseTestCase
         $this->assertContains(MySQLDeadLockTestStub::class, $output);
         $this->assertNotEquals(0, $exitCode);
 
-        $this->assertContains('Executed: 11 test classes, 28 tests (12 retried)', $output);
+        $this->assertContains('Executed: 11 test classes, 30 tests (12 retried)', $output);
     }
 
     public function testExecutionWithLogo()
@@ -124,7 +124,7 @@ class ParallelCommandTest extends BaseTestCase
         $output = $commandTester->getDisplay();
         $this->assertNotEquals(0, $exitCode);
 
-        $this->assertContains('Executed: 11 test classes, 28 tests (12 retried)', $output, 'Precondition failed');
+        $this->assertContains('Executed: 11 test classes, 30 tests (12 retried)', $output, 'Precondition failed');
         $processesCount = 11 + 12;
         $this->assertSame($processesCount, substr_count($output, 'PROCESS STARTED'));
         $this->assertSame($processesCount, substr_count($output, 'PROCESS TERMINATED'));
@@ -164,9 +164,10 @@ class ParallelCommandTest extends BaseTestCase
 
         $output = $commandTester->getDisplay();
         $this->assertNotEquals(0, $exitCode);
-        $this->assertContains('Executed: 1 test classes, 1 tests (0 retried)', $output, 'Precondition failed');
+        $this->assertContains('Executed: 1 test classes, 3 tests (0 retried)', $output, 'Precondition failed');
         $this->assertContains('1 files with DEPRECATION WARNINGS:', $output);
         $this->assertContains(RaisingDeprecationTestStub::DEPRECATION_MESSAGE, $output);
         $this->assertContains('RaisingDeprecationTestStub::testDeprecation', $output);
+        $this->assertNotContains('2)', $output, 'Deprecations are shown more than once per test file');
     }
 }

--- a/tests/Functional/Command/ParallelCommandTest.php
+++ b/tests/Functional/Command/ParallelCommandTest.php
@@ -85,7 +85,7 @@ class ParallelCommandTest extends BaseTestCase
         $this->assertContains(MySQLDeadLockTestStub::class, $output);
         $this->assertNotEquals(0, $exitCode);
 
-        $this->assertContains('Executed: 10 test classes, 27 tests (12 retried)', $output);
+        $this->assertContains('Executed: 11 test classes, 28 tests (12 retried)', $output);
     }
 
     public function testExecutionWithLogo()
@@ -123,8 +123,8 @@ class ParallelCommandTest extends BaseTestCase
         $output = $commandTester->getDisplay();
         $this->assertNotEquals(0, $exitCode);
 
-        $this->assertContains('Executed: 10 test classes, 27 tests (12 retried)', $output, 'Precondition failed');
-        $processesCount = 10 + 12;
+        $this->assertContains('Executed: 11 test classes, 28 tests (12 retried)', $output, 'Precondition failed');
+        $processesCount = 11 + 12;
         $this->assertSame($processesCount, substr_count($output, 'PROCESS STARTED'));
         $this->assertSame($processesCount, substr_count($output, 'PROCESS TERMINATED'));
         $this->assertSame($processesCount, substr_count($output, 'PROCESS PARSING COMPLETED'));
@@ -147,5 +147,24 @@ class ParallelCommandTest extends BaseTestCase
         $this->assertContains('NO TESTS EXECUTED', $output);
         $this->assertContains('0 tests', $output);
         $this->assertSame(0, $exitCode);
+    }
+
+    public function testExecutionWithDeprecationListener()
+    {
+        $application = new Application();
+        $application->add(new ParallelCommand(new ParallelConfiguration()));
+
+        $command = $application->find('run');
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute(array(
+            'command' => $command->getName(),
+            '--configuration' => $this->getConfigForDeprecationListener(),
+        ));
+
+        $output = $commandTester->getDisplay();
+        $this->assertNotEquals(0, $exitCode);
+        $this->assertContains('Executed: 1 test classes, 1 tests (0 retried)', $output, 'Precondition failed');
+        $this->assertContains('1 files with DEPRECATION WARNINGS:', $output);
+        $this->assertContains('deprecation triggered by RaisingDeprecationTestStub::testDeprecation', $output);
     }
 }

--- a/tests/Stub/RaisingDeprecationTestStub.php
+++ b/tests/Stub/RaisingDeprecationTestStub.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Stub;
+
+use PHPUnit\Framework\TestCase;
+
+class RaisingDeprecationTestStub extends TestCase
+{
+    public function testDeprecation()
+    {
+        $this->assertTrue(true, 'This avoids the risky status');
+        @trigger_error('This "Foo" method is deprecated.', E_USER_DEPRECATED);
+    }
+}

--- a/tests/Stub/RaisingDeprecationTestStub.php
+++ b/tests/Stub/RaisingDeprecationTestStub.php
@@ -8,9 +8,21 @@ class RaisingDeprecationTestStub extends TestCase
 {
     const DEPRECATION_MESSAGE = 'This "Foo" method is deprecated';
 
+    /**
+     * @dataProvider multirunDataprovider
+     */
     public function testDeprecation()
     {
         $this->assertTrue(true, 'This avoids the risky status');
         @trigger_error(self::DEPRECATION_MESSAGE, E_USER_DEPRECATED);
+    }
+
+    public function multirunDataprovider()
+    {
+        return [
+            [],
+            [],
+            [],
+        ];
     }
 }

--- a/tests/Stub/RaisingDeprecationTestStub.php
+++ b/tests/Stub/RaisingDeprecationTestStub.php
@@ -6,9 +6,11 @@ use PHPUnit\Framework\TestCase;
 
 class RaisingDeprecationTestStub extends TestCase
 {
+    const DEPRECATION_MESSAGE = 'This "Foo" method is deprecated';
+
     public function testDeprecation()
     {
         $this->assertTrue(true, 'This avoids the risky status');
-        @trigger_error('This "Foo" method is deprecated.', E_USER_DEPRECATED);
+        @trigger_error(self::DEPRECATION_MESSAGE, E_USER_DEPRECATED);
     }
 }

--- a/tests/Stub/phpunit_with_deprecations.xml
+++ b/tests/Stub/phpunit_with_deprecations.xml
@@ -1,0 +1,29 @@
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="../../vendor/autoload.php"
+        >
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="intl.error_level" value="0"/>
+        <ini name="memory_limit" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="deprecations" >
+            <file>./RaisingDeprecationTestStub.php</file>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <file>./RaisingDeprecationTestStub.php</file>
+        </whitelist>
+    </filter>
+
+    <listeners>
+        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+</phpunit>

--- a/tests/Unit/TestResult/TestResultContainerTest.php
+++ b/tests/Unit/TestResult/TestResultContainerTest.php
@@ -56,4 +56,19 @@ class TestResultContainerTest extends BaseUnitTestCase
         $this->assertContains('fail message', $testResult->getFailureMessage());
         $this->assertContains('<tag><[NO OUTPUT FOUND]></tag>', $testResult->getFailureMessage());
     }
+
+    public function testCountTestResultsCountsOnlyResultsWhichProducesSymbols()
+    {
+        $testResult = new TestResultWithAbnormalTermination('function name', 'some message');
+        $process = new StubbedParaunitProcess();
+        $process->setOutput('');
+        $testFormat = $this->prophesize(TestResultFormat::class);
+        $testFormat->getTag()
+            ->willReturn('tag');
+
+        $testResultContainer = new TestResultContainer($testFormat->reveal());
+        $testResultContainer->handleTestResult($process, $testResult);
+
+        $this->assertSame(0, $testResultContainer->countTestResults());
+    }
 }


### PR DESCRIPTION
This PR solves #100: tests that fail are now scanned to search deprecation warnings, like those reported by the [SymfonyTestListener](https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail).

Such failures are reported separately, and with the full test output.