### PR TITLE
Use facile-it codestyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ._*
 *.tgz
 *.phar
+.php_cs.cache
+.php_cs
 bin
 gpg
 public

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -16,12 +16,12 @@ $config->setUsingCache(true);
 $config->setRiskyAllowed(true);
 
 $finder = PhpCsFixer\Finder::create();
-$finder->exclude('tests/Stub/CoverageOutput');
 $finder->in(array (
   0 => 'src',
   1 => 'tests',
 ));
-
+$finder->notName('Coverage4Stub.php');
+$finder->notName('ParseErrorTestStub.php');
 $config->setFinder($finder);
 
 return $config;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,27 @@
+<?php
+
+$additionalRules = [
+    'declare_strict_types' => true,
+    'php_unit_construct' => true,
+    'php_unit_dedicate_assert' => true,
+    'psr4' => true,
+    'random_api_migration' => true,
+];
+$rules = new Facile\CodingStandards\DefaultRules($additionalRules);
+
+$config = PhpCsFixer\Config::create();
+$config->setRules($rules->getRules());
+
+$config->setUsingCache(true);
+$config->setRiskyAllowed(true);
+
+$finder = PhpCsFixer\Finder::create();
+$finder->exclude('tests/Stub/CoverageOutput');
+$finder->in(array (
+  0 => 'src',
+  1 => 'tests',
+));
+
+$config->setFinder($finder);
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - env: PHPSTAN=true
       script: composer phpstan
     - env: CS-FIXER=true
-      script: contrib/contributing.sh 
+      script: composer cs-check 
     - stage: Coverage
       script: phpdbg -qrr bin/phpunit --enforce-time-limit --coverage-clover ./build/logs/clover.xml
       after_success:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,9 +41,11 @@ We follow STRICTLY PSR-1 and PSR-2:
  * https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
  * https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
 
-When you run `composer install`, a pre-commit Git Hook is moved in place: it checks before every commit that the code is
-PSR-2 compliant, and asks you to fix it if it doesn't. **Don't worry!!** You don't have to fix it manually, the script
-will suggest to you the command line to fix it automatically using `phpcbf`.
+Also, this project uses the [Facile.it codestyle package](https://github.com/facile-it/facile-coding-standard), and requires
+stricter rules.
+
+The code style is checked in the Travis CS build; you can check it locally with the `composer cs-check` command, and fix
+automatically all the issues with `composer cs-fix`; please do not commit badly formatted code!
 
 ## Travis and other integrations
 Paraunit has a Travis build integration in place: every time you open a PR (or each time you commit something, if you 

--- a/composer.json
+++ b/composer.json
@@ -1,72 +1,76 @@
 {
-  "name": "facile-it/paraunit",
-  "type": "library",
-  "description": "paraunit",
-  "support": {
-    "issues": "https://github.com/facile-it/paraunit/issues"
-  },
-  "keywords": [
-    "parallel test",
-    "testing",
-    "phpunit"
-  ],
-  "homepage": "http://github.com/facile-it/paraunit",
-  "license": "Apache-2.0",
-  "authors": [
-    {
-      "name": "Francesco Panina",
-      "email": "francesco.panina@gmail.com"
+    "name": "facile-it/paraunit",
+    "type": "library",
+    "description": "paraunit",
+    "support": {
+        "issues": "https://github.com/facile-it/paraunit/issues"
     },
-    {
-      "name": "Alessandro Lai",
-      "email": "alessandro.lai85@gmail.com"
+    "keywords": [
+        "parallel test",
+        "testing",
+        "phpunit"
+    ],
+    "homepage": "http://github.com/facile-it/paraunit",
+    "license": "Apache-2.0",
+    "authors": [
+        {
+            "name": "Francesco Panina",
+            "email": "francesco.panina@gmail.com"
+        },
+        {
+            "name": "Alessandro Lai",
+            "email": "alessandro.lai85@gmail.com"
+        }
+    ],
+    "require": {
+        "php": "^7.0",
+        "symfony/console": "^2.7||^3.0",
+        "symfony/dependency-injection": "^2.7||^3.0",
+        "symfony/config": "^2.7||^3.0",
+        "symfony/stopwatch": "^2.7||^3.0",
+        "symfony/process": "^2.7||^3.0",
+        "symfony/event-dispatcher": "^2.7||^3.0",
+        "phpunit/phpunit": "^6.0.9",
+        "phpunit/php-code-coverage": "^4.0||^5.0",
+        "jean85/pretty-package-versions": "^1.0"
+    },
+    "require-dev": {
+        "codeclimate/php-test-reporter": "0.*",
+        "facile-it/facile-coding-standard": "^0.1.0",
+        "phpstan/phpstan": "^0.8.5",
+        "phpunit/php-invoker": "^1.1",
+        "satooshi/php-coveralls": "~1.0",
+        "scrutinizer/ocular": "^1.4",
+        "symfony/expression-language": "^2.7||^3.0",
+        "symfony/phpunit-bridge": "^3.3"
+    },
+    "bin": [
+        "src/Paraunit/Bin/paraunit"
+    ],
+    "config": {
+        "sort-packages": true,
+        "bin-dir": "bin"
+    },
+    "autoload": {
+        "psr-4": {
+            "Paraunit\\": "src/Paraunit"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests"
+        }
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse src tests -c phpstan.neon -l 7",
+        "cs-check": "php -n bin/php-cs-fixer fix --dry-run --diff",
+        "cs-fix": "php -n bin/php-cs-fixer fix",
+        "post-install-cmd": [
+            "bash contrib/setup.sh"
+        ]
+    },
+    "minimum-stability": "stable",
+    "suggest": {
+        "dama/doctrine-test-bundle": "Useful for Symfony+Doctrine functional testing, providing DB isolation"
     }
-  ],
-  "require": {
-    "php": "^7.0",
-    "symfony/console": "^2.7||^3.0",
-    "symfony/dependency-injection": "^2.7||^3.0",
-    "symfony/config": "^2.7||^3.0",
-    "symfony/stopwatch": "^2.7||^3.0",
-    "symfony/process": "^2.7||^3.0",
-    "symfony/event-dispatcher": "^2.7||^3.0",
-    "phpunit/phpunit": "^6.0.9",
-    "phpunit/php-code-coverage": "^4.0||^5.0",
-    "jean85/pretty-package-versions": "^1.0"
-  },
-  "require-dev": {
-    "codeclimate/php-test-reporter": "0.*",
-    "phpstan/phpstan": "^0.8.5",
-    "phpunit/php-invoker": "^1.1",
-    "satooshi/php-coveralls": "~1.0",
-    "scrutinizer/ocular": "^1.4",
-    "squizlabs/php_codesniffer": "2.*",
-    "symfony/expression-language": "^2.7||^3.0",
-    "symfony/phpunit-bridge": "^3.3"
-  },
-  "bin": ["src/Paraunit/Bin/paraunit"],
-  "config": {
-    "sort-packages": true,
-    "bin-dir": "bin"
-  },
-  "autoload": {
-    "psr-4": {
-      "Paraunit\\": "src/Paraunit"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Tests\\": "tests"
-    }
-  },
-  "scripts": {
-    "phpstan": "phpstan analyse src tests -c phpstan.neon -l 7",
-    "post-install-cmd": [
-      "bash contrib/setup.sh"
-    ]
-  },
-  "minimum-stability": "stable",
-  "suggest": {
-    "dama/doctrine-test-bundle": "Useful for Symfony+Doctrine functional testing, providing DB isolation"
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -64,10 +64,7 @@
     "scripts": {
         "phpstan": "phpstan analyse src tests -c phpstan.neon -l 7",
         "cs-check": "php -n bin/php-cs-fixer fix --dry-run --diff",
-        "cs-fix": "php -n bin/php-cs-fixer fix",
-        "post-install-cmd": [
-            "bash contrib/setup.sh"
-        ]
+        "cs-fix": "php -n bin/php-cs-fixer fix"
     },
     "minimum-stability": "stable",
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ac93e3bdbf444a5a5f23b92ca3ae261",
+    "content-hash": "d38e49150a3091bcb4f1a5a7ada001cf",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -2233,6 +2233,68 @@
             "time": "2017-02-15T22:25:47+00:00"
         },
         {
+            "name": "composer/semver",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2016-08-30T16:08:34+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "v1.4.0",
             "source": {
@@ -2353,6 +2415,180 @@
                 "parser"
             ],
             "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "facile-it/facile-coding-standard",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/facile-it/facile-coding-standard.git",
+                "reference": "cefe697256b12dfd6ed4476525d7e6fa4f2b3ee8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/facile-it/facile-coding-standard/zipball/cefe697256b12dfd6ed4476525d7e6fa4f2b3ee8",
+                "reference": "cefe697256b12dfd6ed4476525d7e6fa4f2b3ee8",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1",
+                "friendsofphp/php-cs-fixer": "^2.4.1",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.3.2",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Facile\\CodingStandards\\Installer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Facile\\CodingStandards\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Facile.it coding standard",
+            "keywords": [
+                "Coding Standard",
+                "facile",
+                "facile.it"
+            ],
+            "time": "2017-08-30T11:12:42+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "04f71e56e03ba2627e345e8c949c80dcef0e683e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/04f71e56e03ba2627e345e8c949c80dcef0e683e",
+                "reference": "04f71e56e03ba2627e345e8c949c80dcef0e683e",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "gecko-packages/gecko-php-unit": "^2.0 || ^3.0",
+                "php": "^5.6 || >=7.0 <7.3",
+                "php-cs-fixer/diff": "^1.2",
+                "symfony/console": "^3.2 || ^4.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0",
+                "symfony/filesystem": "^3.0 || ^4.0",
+                "symfony/finder": "^3.0 || ^4.0",
+                "symfony/options-resolver": "^3.0 || ^4.0",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^3.0 || ^4.0",
+                "symfony/stopwatch": "^3.0 || ^4.0"
+            },
+            "conflict": {
+                "hhvm": "*"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0@dev",
+                "justinrainbow/json-schema": "^5.0",
+                "php-coveralls/php-coveralls": "^1.0.2",
+                "php-cs-fixer/accessible-object": "^1.0",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/phpunit-bridge": "^3.2.2 || ^4.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/Assert/AssertTokensTrait.php",
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2017-11-09T13:31:39+00:00"
+        },
+        {
+            "name": "gecko-packages/gecko-php-unit",
+            "version": "v3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GeckoPackages/GeckoPHPUnit.git",
+                "reference": "6a866551dffc2154c1b091bae3a7877d39c25ca3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GeckoPackages/GeckoPHPUnit/zipball/6a866551dffc2154c1b091bae3a7877d39c25ca3",
+                "reference": "6a866551dffc2154c1b091bae3a7877d39c25ca3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-dom": "When testing with xml.",
+                "ext-libxml": "When testing with xml.",
+                "phpunit/phpunit": "This is an extension for it so make sure you have it some way."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GeckoPackages\\PHPUnit\\": "src/PHPUnit"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Additional PHPUnit asserts and constraints.",
+            "homepage": "https://github.com/GeckoPackages",
+            "keywords": [
+                "extension",
+                "filesystem",
+                "phpunit"
+            ],
+            "time": "2017-08-23T07:46:41+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -3419,6 +3655,102 @@
             "time": "2017-07-12T22:42:45+00:00"
         },
         {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-09-27T21:40:39+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "f0ef6133d674137e902fdf8a6f2e8e97e14a087b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/f0ef6133d674137e902fdf8a6f2e8e97e14a087b",
+                "reference": "f0ef6133d674137e902fdf8a6f2e8e97e14a087b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-10-19T09:58:18+00:00"
+        },
+        {
             "name": "phpcollection/phpcollection",
             "version": "0.5.0",
             "source": {
@@ -3859,84 +4191,6 @@
             "time": "2017-08-14T15:44:52+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
-            "keywords": [
-                "phpcs",
-                "standards"
-            ],
-            "time": "2017-05-22T02:43:20+00:00"
-        },
-        {
             "name": "symfony/cache",
             "version": "v3.3.10",
             "source": {
@@ -4106,6 +4360,60 @@
             "time": "2017-10-02T06:42:24+00:00"
         },
         {
+            "name": "symfony/options-resolver",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "ee4e22978fe885b54ee5da8c7964f0a5301abfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/ee4e22978fe885b54ee5da8c7964f0a5301abfb6",
+                "reference": "ee4e22978fe885b54ee5da8c7964f0a5301abfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2017-07-29T21:54:42+00:00"
+        },
+        {
             "name": "symfony/phpunit-bridge",
             "version": "v3.3.10",
             "source": {
@@ -4216,6 +4524,120 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "apcu",
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-10-11T12:05:26+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff",
+                "reference": "0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-10-11T12:05:26+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "6de4f4884b97abbbed9f0a84a95ff2ff77254254"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/6de4f4884b97abbbed9f0a84a95ff2ff77254254",
+                "reference": "6de4f4884b97abbbed9f0a84a95ff2ff77254254",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
                 "compatibility",
                 "polyfill",
                 "portable",

--- a/contrib/contributing.sh
+++ b/contrib/contributing.sh
@@ -1,33 +1,3 @@
 #!/bin/sh
 
-if [ ! -d ./src ]
-	then
-		echo "src/ folder missing, source code missing"
-		echo "Maybe we are on the gh-pages-source branch?"
-		echo "Skipping PHP code cleanup"
-		exit 0
-	fi
-
-echo "### Paraunit: Tidyng up the src/ code ###"
-
-./bin/phpcs -p --standard=PSR2 --warning-severity=6 --colors src/
-if [ $? != 0 ]
-	then
-		echo "There are some code style issue in the src/ folder."
-		echo "Fix them before submitting your code."
-		echo "Try running ./bin/phpcbf --standard=PSR2 src/"
-		exit 1
-	fi
-
-echo "### Paraunit: Tidyng up the tests/ code ###"
-
-./bin/phpcs -p --standard=PSR2 --warning-severity=6 --colors tests/ --ignore=tests/Stub
-if [ $? != 0 ]
-	then
-		echo "There are some code style issue in the tests/ folder."
-		echo "Fix them before submitting your code."
-		echo "Try running ./bin/phpcbf --standard=PSR2 tests/ --ignore=tests/Stub"
-		exit 1
-	fi
-
-echo "### Paraunit: DONE! ###"
+composer cs-fix || echo "Some code style fixes applied!"

--- a/contrib/contributing.sh
+++ b/contrib/contributing.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-composer cs-fix || echo "Some code style fixes applied!"

--- a/contrib/setup.sh
+++ b/contrib/setup.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cp contrib/contributing.sh .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit

--- a/src/Paraunit/Bin/Paraunit.php
+++ b/src/Paraunit/Bin/Paraunit.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Bin;

--- a/src/Paraunit/Bin/run-paraunit.inc.php
+++ b/src/Paraunit/Bin/run-paraunit.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 if (! ini_get('date.timezone') && ! date_default_timezone_get()) {

--- a/src/Paraunit/Command/CoverageCommand.php
+++ b/src/Paraunit/Command/CoverageCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Command;

--- a/src/Paraunit/Command/ParallelCommand.php
+++ b/src/Paraunit/Command/ParallelCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Command;
@@ -21,7 +22,7 @@ class ParallelCommand extends Command
     /** @var ParallelConfiguration */
     protected $configuration;
 
-    /** @var  PHPUnitOption[] */
+    /** @var PHPUnitOption[] */
     private $phpunitOptions;
 
     /**

--- a/src/Paraunit/Configuration/CoverageConfiguration.php
+++ b/src/Paraunit/Configuration/CoverageConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;
@@ -58,7 +59,7 @@ class CoverageConfiguration extends ParallelConfiguration
         if ($input->getOption('text-to-console')) {
             /** @var OutputInterface $output */
             $output = $container->get(OutputInterface::class);
-            $textToConsole = new TextToConsole($output, (bool)$input->getOption('ansi'));
+            $textToConsole = new TextToConsole($output, (bool) $input->getOption('ansi'));
             $coverageResult->addCoverageProcessor($textToConsole);
         }
 

--- a/src/Paraunit/Configuration/DependencyInjection/CoverageContainerDefinition.php
+++ b/src/Paraunit/Configuration/DependencyInjection/CoverageContainerDefinition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Configuration\DependencyInjection;
 
 use Paraunit\Configuration\PHPDbgBinFile;

--- a/src/Paraunit/Configuration/DependencyInjection/ParallelContainerDefinition.php
+++ b/src/Paraunit/Configuration/DependencyInjection/ParallelContainerDefinition.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration\DependencyInjection;
@@ -68,7 +69,7 @@ class ParallelContainerDefinition
     {
         $container->setDefinition(PHPUnitBinFile::class, new Definition(PHPUnitBinFile::class));
         $container->setDefinition(PHPUnitConfig::class, new Definition(PHPUnitConfig::class, [
-            '%paraunit.phpunit_config_filename%'
+            '%paraunit.phpunit_config_filename%',
         ]));
         $container->setDefinition(TempFilenameFactory::class, new Definition(TempFilenameFactory::class, [
             new Reference(TempDirectory::class),

--- a/src/Paraunit/Configuration/DependencyInjection/ParserDefinition.php
+++ b/src/Paraunit/Configuration/DependencyInjection/ParserDefinition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Configuration\DependencyInjection;
 
 use Paraunit\Configuration\TempFilenameFactory;

--- a/src/Paraunit/Configuration/DependencyInjection/TestResultDefinition.php
+++ b/src/Paraunit/Configuration/DependencyInjection/TestResultDefinition.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Configuration\DependencyInjection;
 
 use Paraunit\TestResult\TestResultContainer;
@@ -22,19 +24,19 @@ class TestResultDefinition
     private function configureTestResultContainer(ContainerBuilder $container)
     {
         $testResultList = new Definition(TestResultList::class);
-        
+
         foreach ($this->getFormatDefinitions() as $name => $format) {
             $formatName = sprintf('paraunit.test_result.%s_format', $name);
             $testResultContainerName = sprintf('paraunit.test_result.%s_container', $name);
-        
+
             $container->setDefinition($formatName, $format);
             $container->setDefinition($testResultContainerName, new Definition(TestResultContainer::class, [
                 new Reference($formatName),
             ]));
-        
+
             $testResultList->addMethodCall('addContainer', [new Reference($testResultContainerName)]);
         }
-        
+
         $container->setDefinition(TestResultList::class, $testResultList);
     }
 

--- a/src/Paraunit/Configuration/EnvVariables.php
+++ b/src/Paraunit/Configuration/EnvVariables.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Configuration;
 
 class EnvVariables

--- a/src/Paraunit/Configuration/OutputFile.php
+++ b/src/Paraunit/Configuration/OutputFile.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;

--- a/src/Paraunit/Configuration/OutputPath.php
+++ b/src/Paraunit/Configuration/OutputPath.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;

--- a/src/Paraunit/Configuration/PHPDbgBinFile.php
+++ b/src/Paraunit/Configuration/PHPDbgBinFile.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;
@@ -51,6 +52,6 @@ class PHPDbgBinFile
         $locator = new Process('command -v phpdbg');
         $locator->run();
 
-        return (string)preg_replace('/\s/', '', $locator->getOutput());
+        return (string) preg_replace('/\s/', '', $locator->getOutput());
     }
 }

--- a/src/Paraunit/Configuration/PHPUnitBinFile.php
+++ b/src/Paraunit/Configuration/PHPUnitBinFile.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;

--- a/src/Paraunit/Configuration/PHPUnitConfig.php
+++ b/src/Paraunit/Configuration/PHPUnitConfig.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;

--- a/src/Paraunit/Configuration/PHPUnitOption.php
+++ b/src/Paraunit/Configuration/PHPUnitOption.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;
@@ -11,13 +12,13 @@ class PHPUnitOption
 {
     /** @var string */
     private $name;
-    
+
     /** @var string|null */
     private $shortName;
-    
+
     /** @var string|null */
     private $value;
-    
+
     /** @var bool */
     private $hasValue;
 

--- a/src/Paraunit/Configuration/ParallelConfiguration.php
+++ b/src/Paraunit/Configuration/ParallelConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;
@@ -10,8 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/src/Paraunit/Configuration/TempFilenameFactory.php
+++ b/src/Paraunit/Configuration/TempFilenameFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Configuration;

--- a/src/Paraunit/Coverage/CoverageFetcher.php
+++ b/src/Paraunit/Coverage/CoverageFetcher.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage;
@@ -15,7 +16,7 @@ use Symfony\Component\Process\Process;
  */
 class CoverageFetcher
 {
-    /** @var  TempFilenameFactory */
+    /** @var TempFilenameFactory */
     private $tempFilenameFactory;
 
     /** @var TestResultHandlerInterface */

--- a/src/Paraunit/Coverage/CoverageMerger.php
+++ b/src/Paraunit/Coverage/CoverageMerger.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage;
@@ -14,10 +15,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class CoverageMerger implements EventSubscriberInterface
 {
-    /** @var  CoverageFetcher */
+    /** @var CoverageFetcher */
     private $coverageFetcher;
 
-    /** @var  CodeCoverage */
+    /** @var CodeCoverage */
     private $coverageData;
 
     /**

--- a/src/Paraunit/Coverage/CoverageResult.php
+++ b/src/Paraunit/Coverage/CoverageResult.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage;

--- a/src/Paraunit/Coverage/Processor/AbstractText.php
+++ b/src/Paraunit/Coverage/Processor/AbstractText.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Coverage\Processor;
 
 use Paraunit\Proxy\Coverage\CodeCoverage;

--- a/src/Paraunit/Coverage/Processor/Clover.php
+++ b/src/Paraunit/Coverage/Processor/Clover.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage\Processor;
@@ -16,7 +17,7 @@ class Clover implements CoverageProcessorInterface
     /** @var PHPUnitClover */
     private $clover;
 
-    /** @var  OutputFile */
+    /** @var OutputFile */
     private $targetFile;
 
     /**

--- a/src/Paraunit/Coverage/Processor/CoverageProcessorInterface.php
+++ b/src/Paraunit/Coverage/Processor/CoverageProcessorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage\Processor;

--- a/src/Paraunit/Coverage/Processor/Crap4j.php
+++ b/src/Paraunit/Coverage/Processor/Crap4j.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage\Processor;

--- a/src/Paraunit/Coverage/Processor/Html.php
+++ b/src/Paraunit/Coverage/Processor/Html.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage\Processor;

--- a/src/Paraunit/Coverage/Processor/Php.php
+++ b/src/Paraunit/Coverage/Processor/Php.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage\Processor;

--- a/src/Paraunit/Coverage/Processor/Text.php
+++ b/src/Paraunit/Coverage/Processor/Text.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage\Processor;
@@ -12,7 +13,7 @@ use Paraunit\Proxy\Coverage\CodeCoverage;
  */
 class Text extends AbstractText
 {
-    /** @var  OutputFile */
+    /** @var OutputFile */
     private $targetFile;
 
     /**

--- a/src/Paraunit/Coverage/Processor/TextToConsole.php
+++ b/src/Paraunit/Coverage/Processor/TextToConsole.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage\Processor;
@@ -12,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class TextToConsole extends AbstractText
 {
-    /** @var  OutputInterface */
+    /** @var OutputInterface */
     private $output;
 
     /**

--- a/src/Paraunit/Coverage/Processor/Xml.php
+++ b/src/Paraunit/Coverage/Processor/Xml.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Coverage\Processor;
@@ -14,10 +15,10 @@ use SebastianBergmann\CodeCoverage\Report\Xml\Facade;
  */
 class Xml implements CoverageProcessorInterface
 {
-    /** @var  Facade */
+    /** @var Facade */
     private $xml;
 
-    /** @var  OutputPath */
+    /** @var OutputPath */
     private $targetPath;
 
     /**

--- a/src/Paraunit/File/Cleaner.php
+++ b/src/Paraunit/File/Cleaner.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\File;
@@ -12,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Cleaner implements EventSubscriberInterface
 {
-    /** @var  TempDirectory */
+    /** @var TempDirectory */
     private $tempDirectory;
 
     /**

--- a/src/Paraunit/File/TempDirectory.php
+++ b/src/Paraunit/File/TempDirectory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\File;
@@ -79,7 +80,7 @@ class TempDirectory
             return;
         }
 
-        if (!mkdir($path) && !is_dir($path)) {
+        if (! mkdir($path) && ! is_dir($path)) {
             throw new \RuntimeException('Unable to create temporary directory ' . $path);
         }
     }

--- a/src/Paraunit/Filter/Filter.php
+++ b/src/Paraunit/Filter/Filter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Filter;
@@ -105,7 +106,7 @@ class Filter
     {
         $excludes = [];
         foreach ($testSuiteNode->getElementsByTagName('exclude') as $excludeNode) {
-            $excludes[] = (string)$excludeNode->nodeValue;
+            $excludes[] = (string) $excludeNode->nodeValue;
         }
 
         return $excludes;
@@ -119,7 +120,7 @@ class Filter
     private function addTestsFromDirectoryNodes(\DOMElement $testSuiteNode, array &$aggregatedFiles, array $excludes)
     {
         foreach ($testSuiteNode->getElementsByTagName('directory') as $directoryNode) {
-            $directory = (string)$directoryNode->nodeValue;
+            $directory = (string) $directoryNode->nodeValue;
 
             $files = $this->fileIteratorFacade->getFilesAsArray(
                 $this->relativePath . $directory,
@@ -141,7 +142,7 @@ class Filter
     private function addTestsFromFileNodes(\DOMElement $testSuiteNode, array &$aggregatedFiles)
     {
         foreach ($testSuiteNode->getElementsByTagName('file') as $fileNode) {
-            $fileName = $this->relativePath . (string)$fileNode->nodeValue;
+            $fileName = $this->relativePath . (string) $fileNode->nodeValue;
             $this->addFileToAggregateArray($aggregatedFiles, $fileName);
         }
     }

--- a/src/Paraunit/Lifecycle/EngineEvent.php
+++ b/src/Paraunit/Lifecycle/EngineEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Lifecycle;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/src/Paraunit/Lifecycle/ProcessEvent.php
+++ b/src/Paraunit/Lifecycle/ProcessEvent.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Lifecycle;

--- a/src/Paraunit/Parser/DeprecationParser.php
+++ b/src/Paraunit/Parser/DeprecationParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Parser;
 
 use Paraunit\Lifecycle\ProcessEvent;

--- a/src/Paraunit/Parser/JSON/AbnormalTerminatedParser.php
+++ b/src/Paraunit/Parser/JSON/AbnormalTerminatedParser.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;

--- a/src/Paraunit/Parser/JSON/GenericParser.php
+++ b/src/Paraunit/Parser/JSON/GenericParser.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;
@@ -13,16 +14,16 @@ use Paraunit\TestResult\TestResultFactory;
  */
 class GenericParser implements ParserChainElementInterface
 {
-    /** @var  TestResultFactory */
+    /** @var TestResultFactory */
     protected $testResultFactory;
 
-    /** @var  TestResultHandlerInterface */
+    /** @var TestResultHandlerInterface */
     protected $testResultContainer;
 
-    /** @var  string */
+    /** @var string */
     protected $status;
 
-    /** @var  string|null */
+    /** @var string|null */
     protected $messageStartsWith;
 
     /**

--- a/src/Paraunit/Parser/JSON/LogFetcher.php
+++ b/src/Paraunit/Parser/JSON/LogFetcher.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;
@@ -14,7 +15,7 @@ class LogFetcher
 {
     const LOG_ENDING_STATUS = 'paraunitEnd';
 
-    /** @var  TempFilenameFactory */
+    /** @var TempFilenameFactory */
     private $fileName;
 
     /**

--- a/src/Paraunit/Parser/JSON/LogParser.php
+++ b/src/Paraunit/Parser/JSON/LogParser.php
@@ -1,11 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;
 
 use Paraunit\Lifecycle\ProcessEvent;
 use Paraunit\Process\AbstractParaunitProcess;
-use Paraunit\TestResult\Interfaces\TestResultBearerInterface;
 use Paraunit\TestResult\Interfaces\TestResultHandlerInterface;
 use Paraunit\TestResult\Interfaces\TestResultInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -26,7 +26,7 @@ class LogParser implements EventSubscriberInterface
     /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
-    /** @var  ParserChainElementInterface[] */
+    /** @var ParserChainElementInterface[] */
     private $parsers;
 
     /**

--- a/src/Paraunit/Parser/JSON/LogPrinter.php
+++ b/src/Paraunit/Parser/JSON/LogPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;
@@ -183,7 +184,7 @@ class LogPrinter extends Util\Printer implements TestListener
         $this->writeArray([
             'event' => 'suiteStart',
             'suite' => $this->currentTestSuiteName,
-            'tests' => count($suite)
+            'tests' => count($suite),
         ]);
     }
 
@@ -201,7 +202,7 @@ class LogPrinter extends Util\Printer implements TestListener
         $this->writeArray([
             'event' => 'testStart',
             'suite' => $this->currentTestSuiteName,
-            'test' => $this->currentTestName
+            'test' => $this->currentTestName,
         ]);
     }
 
@@ -319,7 +320,7 @@ class LogPrinter extends Util\Printer implements TestListener
     {
         /** @var string[] $trace */
         $trace = Util\Filter::getFilteredStacktrace($error, false);
-        
+
         return $trace;
     }
 }

--- a/src/Paraunit/Parser/JSON/ParserChainElementInterface.php
+++ b/src/Paraunit/Parser/JSON/ParserChainElementInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;

--- a/src/Paraunit/Parser/JSON/RetryParser.php
+++ b/src/Paraunit/Parser/JSON/RetryParser.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;

--- a/src/Paraunit/Parser/JSON/TestStartParser.php
+++ b/src/Paraunit/Parser/JSON/TestStartParser.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;

--- a/src/Paraunit/Parser/JSON/UnknownResultParser.php
+++ b/src/Paraunit/Parser/JSON/UnknownResultParser.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Parser\JSON;

--- a/src/Paraunit/Printer/AbstractFinalPrinter.php
+++ b/src/Paraunit/Printer/AbstractFinalPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;
@@ -12,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class AbstractFinalPrinter extends AbstractPrinter
 {
-    /** @var  TestResultList */
+    /** @var TestResultList */
     protected $testResultList;
 
     /**

--- a/src/Paraunit/Printer/AbstractPrinter.php
+++ b/src/Paraunit/Printer/AbstractPrinter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Printer;
 
 use Symfony\Component\Console\Output\OutputInterface;
@@ -10,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class AbstractPrinter
 {
-    /** @var  OutputInterface */
+    /** @var OutputInterface */
     private $output;
 
     /**

--- a/src/Paraunit/Printer/ConsoleFormatter.php
+++ b/src/Paraunit/Printer/ConsoleFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;

--- a/src/Paraunit/Printer/CoveragePrinter.php
+++ b/src/Paraunit/Printer/CoveragePrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;
@@ -15,10 +16,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class CoveragePrinter implements EventSubscriberInterface
 {
-    /** @var  PHPDbgBinFile */
+    /** @var PHPDbgBinFile */
     private $phpdgbBin;
 
-    /** @var  XDebugProxy */
+    /** @var XDebugProxy */
     private $xdebug;
 
     /** @var OutputInterface */

--- a/src/Paraunit/Printer/DebugPrinter.php
+++ b/src/Paraunit/Printer/DebugPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;

--- a/src/Paraunit/Printer/FailuresPrinter.php
+++ b/src/Paraunit/Printer/FailuresPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;
@@ -64,7 +65,7 @@ class FailuresPrinter extends AbstractFinalPrinter implements EventSubscriberInt
 
             if ($testResult instanceof StackTraceInterface) {
                 foreach ($testResult->getTrace() as $traceStep) {
-                    $this->getOutput()->writeln((string)$traceStep);
+                    $this->getOutput()->writeln((string) $traceStep);
                 }
             }
         }

--- a/src/Paraunit/Printer/FilesRecapPrinter.php
+++ b/src/Paraunit/Printer/FilesRecapPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;

--- a/src/Paraunit/Printer/FinalPrinter.php
+++ b/src/Paraunit/Printer/FinalPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;
@@ -68,19 +69,19 @@ class FinalPrinter extends AbstractFinalPrinter implements EventSubscriberInterf
 
     public function onProcessTerminated()
     {
-        $this->processCompleted++;
+        ++$this->processCompleted;
     }
 
     public function onProcessToBeRetried()
     {
-        $this->processRetried++;
+        ++$this->processRetried;
     }
 
     private function printExecutionTime(StopwatchEvent $stopEvent)
     {
         $this->getOutput()->writeln('');
         $this->getOutput()->writeln('');
-        $this->getOutput()->writeln('Execution time -- ' . gmdate('H:i:s', (int)($stopEvent->getDuration() / 1000)));
+        $this->getOutput()->writeln('Execution time -- ' . gmdate('H:i:s', (int) ($stopEvent->getDuration() / 1000)));
     }
 
     private function printTestCounters()

--- a/src/Paraunit/Printer/ProcessPrinter.php
+++ b/src/Paraunit/Printer/ProcessPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;
@@ -18,10 +19,10 @@ class ProcessPrinter implements EventSubscriberInterface
     const MAX_CHAR_LENGTH = 80;
     const COUNTER_CHAR_LENGTH = 5;
 
-    /** @var  SingleResultFormatter */
+    /** @var SingleResultFormatter */
     private $singleResultFormatter;
 
-    /** @var  OutputInterface */
+    /** @var OutputInterface */
     private $output;
 
     /** @var int */

--- a/src/Paraunit/Printer/SharkPrinter.php
+++ b/src/Paraunit/Printer/SharkPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;

--- a/src/Paraunit/Printer/SingleResultFormatter.php
+++ b/src/Paraunit/Printer/SingleResultFormatter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Printer;
@@ -13,7 +14,7 @@ use Paraunit\TestResult\TestResultWithSymbolFormat;
  */
 class SingleResultFormatter
 {
-    /** @var  array */
+    /** @var array */
     private $tagMap;
 
     /**

--- a/src/Paraunit/Process/AbstractParaunitProcess.php
+++ b/src/Paraunit/Process/AbstractParaunitProcess.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Process;

--- a/src/Paraunit/Process/CommandLine.php
+++ b/src/Paraunit/Process/CommandLine.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Process;
 
 use Paraunit\Configuration\PHPUnitBinFile;
@@ -13,7 +15,7 @@ use Paraunit\Parser\JSON\LogPrinter;
  */
 class CommandLine
 {
-    /** @var  PHPUnitBinFile */
+    /** @var PHPUnitBinFile */
     protected $phpUnitBin;
 
     /**

--- a/src/Paraunit/Process/CommandLineWithCoverage.php
+++ b/src/Paraunit/Process/CommandLineWithCoverage.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Process;
@@ -64,7 +65,7 @@ class CommandLineWithCoverage extends CommandLine
         return array_merge(
             [
                 '-qrr',
-                $this->phpUnitBin->getPhpUnitBin()
+                $this->phpUnitBin->getPhpUnitBin(),
             ],
             parent::getOptions($config)
         );

--- a/src/Paraunit/Process/ProcessBuilderFactory.php
+++ b/src/Paraunit/Process/ProcessBuilderFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Process;
 
 use Paraunit\Configuration\EnvVariables;

--- a/src/Paraunit/Process/SymfonyProcessWrapper.php
+++ b/src/Paraunit/Process/SymfonyProcessWrapper.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Process;

--- a/src/Paraunit/Proxy/Coverage/CodeCoverage.php
+++ b/src/Paraunit/Proxy/Coverage/CodeCoverage.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Proxy\Coverage;

--- a/src/Paraunit/Proxy/Coverage/FakeDriver.php
+++ b/src/Paraunit/Proxy/Coverage/FakeDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Proxy\Coverage;

--- a/src/Paraunit/Proxy/PHPUnitUtilXMLProxy.php
+++ b/src/Paraunit/Proxy/PHPUnitUtilXMLProxy.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Proxy;

--- a/src/Paraunit/Proxy/XDebugProxy.php
+++ b/src/Paraunit/Proxy/XDebugProxy.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Proxy;

--- a/src/Paraunit/Runner/Pipeline.php
+++ b/src/Paraunit/Runner/Pipeline.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Runner;
 
 use Paraunit\Configuration\EnvVariables;

--- a/src/Paraunit/Runner/PipelineCollection.php
+++ b/src/Paraunit/Runner/PipelineCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Runner;
 
 use Paraunit\Process\AbstractParaunitProcess;
@@ -17,7 +19,7 @@ class PipelineCollection
     {
         $this->pipelines = new \SplFixedArray($maxProcessNumber);
 
-        for ($pipelineNumber = 1; $pipelineNumber <= $maxProcessNumber; $pipelineNumber++) {
+        for ($pipelineNumber = 1; $pipelineNumber <= $maxProcessNumber; ++$pipelineNumber) {
             $this->pipelines->offsetSet($pipelineNumber - 1, $pipelineFactory->create($pipelineNumber));
         }
     }

--- a/src/Paraunit/Runner/PipelineFactory.php
+++ b/src/Paraunit/Runner/PipelineFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Runner;
 
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/src/Paraunit/Runner/Runner.php
+++ b/src/Paraunit/Runner/Runner.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\Runner;
@@ -17,7 +18,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Runner implements EventSubscriberInterface
 {
-    /** @var  ProcessBuilderFactory */
+    /** @var ProcessBuilderFactory */
     private $processBuilderFactory;
 
     /** @var EventDispatcherInterface */

--- a/src/Paraunit/TestResult/FullTestResult.php
+++ b/src/Paraunit/TestResult/FullTestResult.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/src/Paraunit/TestResult/Interfaces/FailureMessageInterface.php
+++ b/src/Paraunit/TestResult/Interfaces/FailureMessageInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult\Interfaces;

--- a/src/Paraunit/TestResult/Interfaces/FunctionNameInterface.php
+++ b/src/Paraunit/TestResult/Interfaces/FunctionNameInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult\Interfaces;

--- a/src/Paraunit/TestResult/Interfaces/PrintableTestResultInterface.php
+++ b/src/Paraunit/TestResult/Interfaces/PrintableTestResultInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult\Interfaces;

--- a/src/Paraunit/TestResult/Interfaces/StackTraceInterface.php
+++ b/src/Paraunit/TestResult/Interfaces/StackTraceInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult\Interfaces;

--- a/src/Paraunit/TestResult/Interfaces/TestResultBearerInterface.php
+++ b/src/Paraunit/TestResult/Interfaces/TestResultBearerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult\Interfaces;

--- a/src/Paraunit/TestResult/Interfaces/TestResultContainerInterface.php
+++ b/src/Paraunit/TestResult/Interfaces/TestResultContainerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult\Interfaces;

--- a/src/Paraunit/TestResult/Interfaces/TestResultHandlerInterface.php
+++ b/src/Paraunit/TestResult/Interfaces/TestResultHandlerInterface.php
@@ -1,6 +1,6 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 
 namespace Paraunit\TestResult\Interfaces;
 

--- a/src/Paraunit/TestResult/Interfaces/TestResultInterface.php
+++ b/src/Paraunit/TestResult/Interfaces/TestResultInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult\Interfaces;

--- a/src/Paraunit/TestResult/MuteTestResult.php
+++ b/src/Paraunit/TestResult/MuteTestResult.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/src/Paraunit/TestResult/NullTestResult.php
+++ b/src/Paraunit/TestResult/NullTestResult.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/src/Paraunit/TestResult/TestResultContainer.php
+++ b/src/Paraunit/TestResult/TestResultContainer.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/src/Paraunit/TestResult/TestResultFactory.php
+++ b/src/Paraunit/TestResult/TestResultFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/src/Paraunit/TestResult/TestResultFormat.php
+++ b/src/Paraunit/TestResult/TestResultFormat.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/src/Paraunit/TestResult/TestResultList.php
+++ b/src/Paraunit/TestResult/TestResultList.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;
@@ -9,7 +10,7 @@ namespace Paraunit\TestResult;
  */
 class TestResultList
 {
-    /** @var  TestResultContainer[] */
+    /** @var TestResultContainer[] */
     private $testResultContainers;
 
     public function __construct()

--- a/src/Paraunit/TestResult/TestResultWithAbnormalTermination.php
+++ b/src/Paraunit/TestResult/TestResultWithAbnormalTermination.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/src/Paraunit/TestResult/TestResultWithMessage.php
+++ b/src/Paraunit/TestResult/TestResultWithMessage.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/src/Paraunit/TestResult/TestResultWithSymbolFormat.php
+++ b/src/Paraunit/TestResult/TestResultWithSymbolFormat.php
@@ -1,6 +1,6 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 
 namespace Paraunit\TestResult;
 

--- a/src/Paraunit/TestResult/TraceStep.php
+++ b/src/Paraunit/TestResult/TraceStep.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Paraunit\TestResult;

--- a/tests/BaseFunctionalTestCase.php
+++ b/tests/BaseFunctionalTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests;

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests;
@@ -10,12 +11,12 @@ use Paraunit\File\TempDirectory;
 use Paraunit\Lifecycle\ProcessEvent;
 use Paraunit\Parser\JSON\LogParser;
 use Prophecy\Argument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Tests\Stub\PHPUnitJSONLogOutput\JSONLogStub;
 use Tests\Stub\StubbedParaunitProcess;
 use Tests\Stub\UnformattedOutputStub;
-use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Class BaseIntegrationTestCase
@@ -26,7 +27,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
     /** @var ContainerBuilder */
     protected $container;
 
-    /** @var  ParallelConfiguration */
+    /** @var ParallelConfiguration */
     protected $configuration;
 
     /** @var string */
@@ -38,12 +39,12 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
     /**
      * {@inheritdoc}
      */
-    public function __construct($name = null, array $data = array(), $dataName = '')
+    public function __construct($name = null, array $data = [], $dataName = '')
     {
         parent::__construct($name, $data, $dataName);
 
         $this->configuration = new ParallelConfiguration();
-        $this->options = array();
+        $this->options = [];
         $this->setOption('configuration', $this->getStubPath() . DIRECTORY_SEPARATOR . 'phpunit_for_stubs.xml');
     }
 
@@ -108,7 +109,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
         /** @var LogParser $logParser */
         $logParser = $this->container->get(LogParser::class);
 
-        $logsToBeProcessed = array(
+        $logsToBeProcessed = [
             JSONLogStub::TWO_ERRORS_TWO_FAILURES,
             JSONLogStub::ALL_GREEN,
             JSONLogStub::ONE_ERROR,
@@ -119,7 +120,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
             JSONLogStub::FATAL_ERROR,
             JSONLogStub::SEGFAULT,
             JSONLogStub::UNKNOWN,
-        );
+        ];
 
         $process = new StubbedParaunitProcess();
         $processEvent = new ProcessEvent($process);

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests;

--- a/tests/BaseUnitTestCase.php
+++ b/tests/BaseUnitTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests;

--- a/tests/Functional/Command/ParallelCommandTest.php
+++ b/tests/Functional/Command/ParallelCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Command;
@@ -70,10 +71,10 @@ class ParallelCommandTest extends BaseTestCase
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
-        $exitCode = $commandTester->execute(array(
+        $exitCode = $commandTester->execute([
             'command' => $command->getName(),
             '--configuration' => $configurationPath,
-        ));
+        ]);
 
         $output = $commandTester->getDisplay();
         $this->assertNotContains('BBBBbBBBBBBB', $output, 'Shark logo shown but not required');
@@ -97,11 +98,11 @@ class ParallelCommandTest extends BaseTestCase
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array(
+        $commandTester->execute([
             'command' => $command->getName(),
             '--logo' => $configurationPath,
             '--filter' => 'doNotExecuteAnyTestSoItsFaster',
-        ));
+        ]);
 
         $output = $commandTester->getDisplay();
         $this->assertContains('BBBBbBBBBBBB', $output, 'Shark logo missing');
@@ -115,11 +116,11 @@ class ParallelCommandTest extends BaseTestCase
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
-        $exitCode = $commandTester->execute(array(
+        $exitCode = $commandTester->execute([
             'command' => $command->getName(),
             '--configuration' => $configurationPath,
             '--debug' => true,
-        ));
+        ]);
 
         $output = $commandTester->getDisplay();
         $this->assertNotEquals(0, $exitCode);
@@ -139,10 +140,10 @@ class ParallelCommandTest extends BaseTestCase
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
-        $exitCode = $commandTester->execute(array(
+        $exitCode = $commandTester->execute([
             'command' => $command->getName(),
             '--filter' => 'do_not_execute_anything',
-        ));
+        ]);
 
         $output = $commandTester->getDisplay();
         $this->assertContains('NO TESTS EXECUTED', $output);
@@ -157,10 +158,10 @@ class ParallelCommandTest extends BaseTestCase
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
-        $exitCode = $commandTester->execute(array(
+        $exitCode = $commandTester->execute([
             'command' => $command->getName(),
             '--configuration' => $this->getConfigForDeprecationListener(),
-        ));
+        ]);
 
         $output = $commandTester->getDisplay();
         $this->assertNotEquals(0, $exitCode);

--- a/tests/Functional/Configuration/PHPDbgBinFileTest.php
+++ b/tests/Functional/Configuration/PHPDbgBinFileTest.php
@@ -1,6 +1,6 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 
 namespace Tests\Functional\Configuration;
 

--- a/tests/Functional/Parser/JSON/AbnormalTerminatedParserTest.php
+++ b/tests/Functional/Parser/JSON/AbnormalTerminatedParserTest.php
@@ -1,13 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Parser\JSON;
 
 use Paraunit\Parser\JSON\AbnormalTerminatedParser;
 use Paraunit\Parser\JSON\LogFetcher;
+use Paraunit\TestResult\TestResultWithAbnormalTermination;
 use Tests\BaseFunctionalTestCase;
 use Tests\Stub\StubbedParaunitProcess;
-use Paraunit\TestResult\TestResultWithAbnormalTermination;
 
 /**
  * Class AbnormalTerminatedParserTest

--- a/tests/Functional/Parser/JSON/LogParserTest.php
+++ b/tests/Functional/Parser/JSON/LogParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Parser\JSON;

--- a/tests/Functional/Parser/JSON/LogPrinterTest.php
+++ b/tests/Functional/Parser/JSON/LogPrinterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Parser\JSON;

--- a/tests/Functional/Printer/ConsoleFormatterTest.php
+++ b/tests/Functional/Printer/ConsoleFormatterTest.php
@@ -1,13 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Printer;
 
 use Paraunit\Printer\ConsoleFormatter;
 use Paraunit\TestResult\TestResultContainer;
+use Symfony\Component\Console\Formatter\OutputFormatterStyleInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Tests\BaseFunctionalTestCase;
-use Symfony\Component\Console\Formatter\OutputFormatterStyleInterface;
 
 /**
  * Class ConsoleFormatterTest

--- a/tests/Functional/Printer/FailuresPrinterTest.php
+++ b/tests/Functional/Printer/FailuresPrinterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Printer;

--- a/tests/Functional/Printer/FilesRecapPrinterTest.php
+++ b/tests/Functional/Printer/FilesRecapPrinterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Printer;

--- a/tests/Functional/Printer/SingleResultFormatterTest.php
+++ b/tests/Functional/Printer/SingleResultFormatterTest.php
@@ -1,14 +1,15 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Printer;
 
 use Paraunit\Printer\SingleResultFormatter;
+use Paraunit\TestResult\Interfaces\PrintableTestResultInterface;
 use Paraunit\TestResult\TestResultFormat;
 use Paraunit\TestResult\TestResultList;
 use Paraunit\TestResult\TestResultWithSymbolFormat;
 use Tests\BaseFunctionalTestCase;
-use Paraunit\TestResult\Interfaces\PrintableTestResultInterface;
 
 /**
  * Class SingleResultFormatterTest

--- a/tests/Functional/Runner/RunnerTest.php
+++ b/tests/Functional/Runner/RunnerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Runner;
@@ -36,7 +37,7 @@ class RunnerTest extends BaseIntegrationTestCase
             '...',
             '     3',
             'Execution time',
-            'Executed: 1 test classes, 3 tests (0 retried)'
+            'Executed: 1 test classes, 3 tests (0 retried)',
         ]);
     }
 

--- a/tests/Functional/Runner/RunnerWithCoverageTest.php
+++ b/tests/Functional/Runner/RunnerWithCoverageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Functional\Runner;
@@ -29,7 +30,7 @@ class RunnerWithCoverageTest extends BaseIntegrationTestCase
         $runner = $this->container->get(Runner::class);
 
         $exitCode = $runner->run();
-        
+
         $output = $this->getConsoleOutput();
         $this->assertEquals(0, $exitCode, $output->getOutput());
         $this->assertNotContains('COVERAGE NOT FETCHED', $output->getOutput());

--- a/tests/Stub/BrokenTestBase.php
+++ b/tests/Stub/BrokenTestBase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/BrokenTestInterface.php
+++ b/tests/Stub/BrokenTestInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/CoverageOutput/WrongCoverageStub.php
+++ b/tests/Stub/CoverageOutput/WrongCoverageStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 return new \DateTime();

--- a/tests/Stub/EntityManagerClosedTestStub.php
+++ b/tests/Stub/EntityManagerClosedTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/FatalErrorTestStub.php
+++ b/tests/Stub/FatalErrorTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;
@@ -13,7 +14,7 @@ class FatalErrorTestStub extends BrokenTestBase implements BrokenTestInterface
     {
         ini_set('memory_limit', '2M');
 
-        $arr = array();
+        $arr = [];
 
         while (true) {
             $arr[] = 'Allocated memory... allocated memory everywhere!';

--- a/tests/Stub/MissingProviderTestStub.php
+++ b/tests/Stub/MissingProviderTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/MySQLDeadLockTestStub.php
+++ b/tests/Stub/MySQLDeadLockTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/MySQLLockTimeoutTestStub.php
+++ b/tests/Stub/MySQLLockTimeoutTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/PHPUnitJSONLogOutput/JSONLogStub.php
+++ b/tests/Stub/PHPUnitJSONLogOutput/JSONLogStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub\PHPUnitJSONLogOutput;
@@ -38,7 +39,7 @@ class JSONLogStub
      */
     public static function getCleanOutputFileContent($filename)
     {
-        $fullFilename =  __DIR__ . DIRECTORY_SEPARATOR . $filename . '.json';
+        $fullFilename = __DIR__ . DIRECTORY_SEPARATOR . $filename . '.json';
         if (! file_exists($fullFilename)) {
             throw new \Exception('Unknown file stub: ' . $filename);
         }

--- a/tests/Stub/RaisingDeprecationTestStub.php
+++ b/tests/Stub/RaisingDeprecationTestStub.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Stub;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Stub/RaisingNoticeTestStub.php
+++ b/tests/Stub/RaisingNoticeTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/SQLiteDeadLockTestStub.php
+++ b/tests/Stub/SQLiteDeadLockTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/SegFaultTestStub.php
+++ b/tests/Stub/SegFaultTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/StubbedParaunitProcess.php
+++ b/tests/Stub/StubbedParaunitProcess.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;
@@ -24,7 +25,7 @@ class StubbedParaunitProcess extends AbstractParaunitProcess
      * {@inheritdoc}
      */
     public function __construct(
-        string $filename = 'testFilename', 
+        string $filename = 'testFilename',
         string $uniqueId = null
     ) {
         parent::__construct($filename);

--- a/tests/Stub/ThreeGreenTestStub.php
+++ b/tests/Stub/ThreeGreenTestStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Stub/UnformattedOutputStub.php
+++ b/tests/Stub/UnformattedOutputStub.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Stub;

--- a/tests/Unit/Bin/ParaunitTest.php
+++ b/tests/Unit/Bin/ParaunitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Bin;

--- a/tests/Unit/Command/CoverageCommandTest.php
+++ b/tests/Unit/Command/CoverageCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Command;

--- a/tests/Unit/Command/ParallelCommandTest.php
+++ b/tests/Unit/Command/ParallelCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Command;

--- a/tests/Unit/Configuration/CoverageConfigurationTest.php
+++ b/tests/Unit/Configuration/CoverageConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Configuration;
@@ -26,11 +27,11 @@ use Paraunit\Runner\Runner;
 use Paraunit\TestResult\TestResultFactory;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Tests\BaseUnitTestCase;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class ParaunitCoverageTest

--- a/tests/Unit/Configuration/OutputFileTest.php
+++ b/tests/Unit/Configuration/OutputFileTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Configuration;

--- a/tests/Unit/Configuration/OutputPathTest.php
+++ b/tests/Unit/Configuration/OutputPathTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Configuration;

--- a/tests/Unit/Configuration/PHPUnitBinFileTest.php
+++ b/tests/Unit/Configuration/PHPUnitBinFileTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Configuration;

--- a/tests/Unit/Configuration/PHPUnitConfigTest.php
+++ b/tests/Unit/Configuration/PHPUnitConfigTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Configuration;

--- a/tests/Unit/Configuration/ParallelConfigurationTest.php
+++ b/tests/Unit/Configuration/ParallelConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Configuration;
@@ -55,7 +56,7 @@ class ParallelConfigurationTest extends BaseUnitTestCase
             'paraunit.string_filter' => 'text',
             'paraunit.phpunit_config_filename' => $this->getConfigForStubs(),
         ];
-        
+
         foreach ($requiredParameters as $parameterName => $expectedValue) {
             $this->assertTrue($container->hasParameter($parameterName), 'Parameter missing: ' . $parameterName);
             $this->assertEquals($expectedValue, $container->getParameter($parameterName));
@@ -84,7 +85,7 @@ class ParallelConfigurationTest extends BaseUnitTestCase
             $container->get($definition); // test instantiation, to prevent misconfigurations
         }
     }
- 
+
     public function testBuildContainerWithDebug()
     {
         $paraunit = new ParallelConfiguration();

--- a/tests/Unit/Configuration/TempFilenameFactoryTest.php
+++ b/tests/Unit/Configuration/TempFilenameFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Configuration;

--- a/tests/Unit/Coverage/CoverageFetcherTest.php
+++ b/tests/Unit/Coverage/CoverageFetcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage;

--- a/tests/Unit/Coverage/CoverageMergerTest.php
+++ b/tests/Unit/Coverage/CoverageMergerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage;

--- a/tests/Unit/Coverage/CoverageResultTest.php
+++ b/tests/Unit/Coverage/CoverageResultTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage;
@@ -21,9 +22,9 @@ class CoverageResultTest extends BaseTestCase
         $merger = $this->prophesize(CoverageMerger::class);
         $merger->getCoverageData()
             ->willReturn(new CodeCoverage());
-        
+
         $coverageResult = new CoverageResult($merger->reveal());
-        
+
         $coverageResult->addCoverageProcessor($this->mockCoverageProcessorInterface());
         $coverageResult->addCoverageProcessor($this->mockCoverageProcessorInterface());
         $coverageResult->addCoverageProcessor($this->mockCoverageProcessorInterface());
@@ -39,7 +40,7 @@ class CoverageResultTest extends BaseTestCase
         $coverageProcessor = $this->prophesize('Paraunit\Coverage\Processor\CoverageProcessorInterface');
         $coverageProcessor->process(Argument::cetera())
             ->shouldBeCalledTimes(1);
-        
+
         return $coverageProcessor->reveal();
     }
 }

--- a/tests/Unit/Coverage/Processor/CloverTest.php
+++ b/tests/Unit/Coverage/Processor/CloverTest.php
@@ -1,11 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage\Processor;
 
 use Paraunit\Configuration\OutputFile;
 use Paraunit\Coverage\Processor\Clover;
-use Paraunit\Coverage\Processor\Text;
 use Paraunit\Proxy\Coverage\CodeCoverage;
 use Tests\BaseUnitTestCase;
 

--- a/tests/Unit/Coverage/Processor/Crap4jTest.php
+++ b/tests/Unit/Coverage/Processor/Crap4jTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage\Processor;

--- a/tests/Unit/Coverage/Processor/HtmlTest.php
+++ b/tests/Unit/Coverage/Processor/HtmlTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage\Processor;

--- a/tests/Unit/Coverage/Processor/PhpTest.php
+++ b/tests/Unit/Coverage/Processor/PhpTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage\Processor;

--- a/tests/Unit/Coverage/Processor/TextTest.php
+++ b/tests/Unit/Coverage/Processor/TextTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage\Processor;

--- a/tests/Unit/Coverage/Processor/TextToConsoleTest.php
+++ b/tests/Unit/Coverage/Processor/TextToConsoleTest.php
@@ -1,10 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage\Processor;
 
-use Paraunit\Configuration\OutputFile;
-use Paraunit\Coverage\Processor\Text;
 use Paraunit\Coverage\Processor\TextToConsole;
 use Paraunit\Proxy\Coverage\CodeCoverage;
 use Tests\BaseUnitTestCase;
@@ -22,7 +21,7 @@ class TextToConsoleTest extends BaseUnitTestCase
         $text = new TextToConsole($output, true);
 
         $text->process(new CodeCoverage());
-        
+
         $this->assertContains('Code Coverage Report', $output->getOutput());
     }
 }

--- a/tests/Unit/Coverage/Processor/XmlTest.php
+++ b/tests/Unit/Coverage/Processor/XmlTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Coverage\Processor;

--- a/tests/Unit/Filter/FilterTest.php
+++ b/tests/Unit/Filter/FilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Filter;
@@ -15,10 +16,10 @@ use Tests\BaseUnitTestCase;
  */
 class FilterTest extends BaseUnitTestCase
 {
-    /** @var  string */
+    /** @var string */
     private $absoluteConfigBaseDir;
 
-    public function __construct($name = null, array $data = array(), $dataName = '')
+    public function __construct($name = null, array $data = [], $dataName = '')
     {
         parent::__construct($name, $data, $dataName);
         $this->absoluteConfigBaseDir = dirname(__DIR__, 2) . '/Stub/StubbedXMLConfigs' . DIRECTORY_SEPARATOR;

--- a/tests/Unit/Parser/JSON/GenericParserTest.php
+++ b/tests/Unit/Parser/JSON/GenericParserTest.php
@@ -1,15 +1,16 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Parser\JSON;
 
 use Paraunit\Parser\JSON\GenericParser;
 use Paraunit\TestResult\FullTestResult;
+use Paraunit\TestResult\TestResultContainer;
+use Paraunit\TestResult\TestResultFactory;
 use Prophecy\Argument;
 use Tests\BaseUnitTestCase;
 use Tests\Stub\StubbedParaunitProcess;
-use Paraunit\TestResult\TestResultFactory;
-use Paraunit\TestResult\TestResultContainer;
 
 /**
  * Class GenericParserTest
@@ -38,7 +39,7 @@ class GenericParserTest extends BaseUnitTestCase
         $factory->createFromLog($log)->willReturn($result);
         $resultContainer = $this->prophesize(TestResultContainer::class);
         $resultContainer->handleTestResult(Argument::cetera())
-            ->shouldBeCalledTimes((int)$shouldMatch);
+            ->shouldBeCalledTimes((int) $shouldMatch);
 
         $parser = new GenericParser($factory->reveal(), $resultContainer->reveal(), $statusToMatch, $startsWithToMatch);
 

--- a/tests/Unit/Parser/JSON/LogFetcherTest.php
+++ b/tests/Unit/Parser/JSON/LogFetcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Parser\JSON;
@@ -27,7 +28,7 @@ class LogFetcherTest extends BaseUnitTestCase
         $logs = $fetcher->fetch($process);
 
         $this->assertNotNull($logs, 'Fetcher returning a non-array');
-        $this->assertTrue(is_array($logs), 'Fetcher returning a non-array');
+        $this->assertInternalType('array', $logs, 'Fetcher returning a non-array');
         $this->assertCount(1, $logs, 'Log ending missing');
         $this->assertContainsOnlyInstancesOf(\stdClass::class, $logs);
 
@@ -52,7 +53,7 @@ class LogFetcherTest extends BaseUnitTestCase
         $logs = $fetcher->fetch($process);
 
         $this->assertNotNull($logs, 'Fetcher returning a non-array');
-        $this->assertTrue(is_array($logs), 'Fetcher returning a non-array');
+        $this->assertInternalType('array', $logs, 'Fetcher returning a non-array');
         $this->assertCount(20 + 1, $logs, 'Log ending missing');
         $this->assertContainsOnlyInstancesOf(\stdClass::class, $logs);
 

--- a/tests/Unit/Parser/JSON/LogParserTest.php
+++ b/tests/Unit/Parser/JSON/LogParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Parser\JSON;
@@ -108,7 +109,7 @@ class LogParserTest extends BaseUnitTestCase
             ProcessEvent::PROCESS_PARSING_COMPLETED,
             Argument::type('Paraunit\Lifecycle\ProcessEvent')
         )
-            ->shouldBeCalledTimes((int)($emptyTestsCount === 0));
+            ->shouldBeCalledTimes((int) ($emptyTestsCount === 0));
 
         return new LogParser($logLocator->reveal(), $noTestExecutedContainer->reveal(), $eventDispatcher->reveal());
     }

--- a/tests/Unit/Parser/JSON/LogPrinterTest.php
+++ b/tests/Unit/Parser/JSON/LogPrinterTest.php
@@ -1,10 +1,10 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Parser\JSON;
 
 use Paraunit\Configuration\EnvVariables;
-use Paraunit\File\Cleaner;
 use Paraunit\Parser\JSON\LogPrinter;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Test;

--- a/tests/Unit/Parser/JSON/RetryParserTest.php
+++ b/tests/Unit/Parser/JSON/RetryParserTest.php
@@ -1,9 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Parser\JSON;
 
 use Paraunit\Parser\JSON\RetryParser;
+use Paraunit\TestResult\Interfaces\TestResultHandlerInterface;
+use Paraunit\TestResult\MuteTestResult;
 use Prophecy\Argument;
 use Tests\BaseUnitTestCase;
 use Tests\Stub\EntityManagerClosedTestStub;
@@ -12,8 +15,6 @@ use Tests\Stub\MySQLLockTimeoutTestStub;
 use Tests\Stub\PHPUnitJSONLogOutput\JSONLogStub;
 use Tests\Stub\SQLiteDeadLockTestStub;
 use Tests\Stub\StubbedParaunitProcess;
-use Paraunit\TestResult\MuteTestResult;
-use Paraunit\TestResult\Interfaces\TestResultHandlerInterface;
 
 /**
  * Class RetryParserTest
@@ -102,7 +103,7 @@ class RetryParserTest extends BaseUnitTestCase
     {
         $resultHandler = $this->prophesize(TestResultHandlerInterface::class);
         $resultHandler->handleTestResult(Argument::cetera())
-            ->shouldBeCalledTimes((int)$shouldBeCalled);
+            ->shouldBeCalledTimes((int) $shouldBeCalled);
 
         return $resultHandler->reveal();
     }

--- a/tests/Unit/Parser/JSON/TestStartParserTest.php
+++ b/tests/Unit/Parser/JSON/TestStartParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Parser\JSON;

--- a/tests/Unit/Parser/JSON/UnknownResultParserTest.php
+++ b/tests/Unit/Parser/JSON/UnknownResultParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Parser\JSON;

--- a/tests/Unit/Printer/CoveragePrinterTest.php
+++ b/tests/Unit/Printer/CoveragePrinterTest.php
@@ -1,10 +1,10 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Printer;
 
 use Paraunit\Configuration\PHPDbgBinFile;
-use Paraunit\Lifecycle\EngineEvent;
 use Paraunit\Printer\CoveragePrinter;
 use Paraunit\Proxy\XDebugProxy;
 use Tests\BaseUnitTestCase;

--- a/tests/Unit/Printer/DebugPrinterTest.php
+++ b/tests/Unit/Printer/DebugPrinterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Printer;
 
 use Paraunit\Lifecycle\ProcessEvent;
@@ -31,9 +33,9 @@ class DebugPrinterTest extends BaseUnitTestCase
         $output = new UnformattedOutputStub();
         $printer = new DebugPrinter($output);
         $process = new StubbedParaunitProcess();
-        
+
         $printer->onProcessStarted(new ProcessEvent($process));
-        
+
         $this->assertContains('PROCESS STARTED', $output->getOutput());
         $this->assertContains($process->getFilename(), $output->getOutput());
         $this->assertContains($process->getCommandLine(), $output->getOutput());
@@ -45,9 +47,9 @@ class DebugPrinterTest extends BaseUnitTestCase
         $printer = new DebugPrinter($output);
         $process = new StubbedParaunitProcess();
         $process->setTestClassName('Some\Class\Name');
-        
+
         $printer->onProcessTerminated(new ProcessEvent($process));
-        
+
         $this->assertContains('PROCESS TERMINATED', $output->getOutput());
         $this->assertContains($process->getFilename(), $output->getOutput());
         $this->assertContains($process->getTestClassName(), $output->getOutput());
@@ -57,9 +59,9 @@ class DebugPrinterTest extends BaseUnitTestCase
     {
         $output = new UnformattedOutputStub();
         $printer = new DebugPrinter($output);
-        
+
         $printer->onProcessParsingCompleted();
-        
+
         $this->assertContains('PROCESS PARSING COMPLETED', $output->getOutput());
         $this->assertContains('RESULTS', $output->getOutput());
     }
@@ -71,7 +73,7 @@ class DebugPrinterTest extends BaseUnitTestCase
         $process = new StubbedParaunitProcess();
 
         $printer->onProcessToBeRetried(new ProcessEvent($process));
-        
+
         $this->assertContains('PROCESS TO BE RETRIED', $output->getOutput());
         $this->assertContains($process->getFilename(), $output->getOutput());
     }

--- a/tests/Unit/Printer/FinalPrinterTest.php
+++ b/tests/Unit/Printer/FinalPrinterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Printer;

--- a/tests/Unit/Printer/ProcessPrinterTest.php
+++ b/tests/Unit/Printer/ProcessPrinterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Printer;
@@ -56,7 +57,7 @@ class ProcessPrinterTest extends BaseUnitTestCase
     public function testOnProcessParsingCompletedAddsCounterAndNewlineAtFullRow(int $times, int $newLineTimes)
     {
         $process = new StubbedParaunitProcess();
-        for ($i = 0; $i < $times; $i++) {
+        for ($i = 0; $i < $times; ++$i) {
             $process->addTestResult($this->mockPrintableTestResult());
         }
 
@@ -96,7 +97,7 @@ class ProcessPrinterTest extends BaseUnitTestCase
     public function testOnProcessParsingCompletedAndOnEngineEndWorkWellTogether()
     {
         $process = new StubbedParaunitProcess();
-        for ($i = 0; $i < 100; $i++) {
+        for ($i = 0; $i < 100; ++$i) {
             $process->addTestResult($this->mockPrintableTestResult());
         }
 

--- a/tests/Unit/Printer/SingleResultFormatterTest.php
+++ b/tests/Unit/Printer/SingleResultFormatterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Printer;

--- a/tests/Unit/Process/CommandLineTest.php
+++ b/tests/Unit/Process/CommandLineTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Process;
@@ -6,7 +7,6 @@ namespace Tests\Unit\Process;
 use Paraunit\Configuration\PHPUnitBinFile;
 use Paraunit\Configuration\PHPUnitConfig;
 use Paraunit\Configuration\PHPUnitOption;
-use Paraunit\Configuration\TempFilenameFactory;
 use Paraunit\Parser\JSON\LogPrinter;
 use Paraunit\Process\CommandLine;
 use Tests\BaseUnitTestCase;
@@ -24,7 +24,7 @@ class CommandLineTest extends BaseUnitTestCase
 
         $cli = new CommandLine($phpunit->reveal());
 
-        $this->assertEquals(array('php', 'path/to/phpunit'), $cli->getExecutable());
+        $this->assertEquals(['php', 'path/to/phpunit'], $cli->getExecutable());
     }
 
     public function testGetOptionsFor()
@@ -35,16 +35,16 @@ class CommandLineTest extends BaseUnitTestCase
 
         $optionWithValue = new PHPUnitOption('optVal');
         $optionWithValue->setValue('value');
-        $config->getPhpunitOptions()->willReturn(array(
+        $config->getPhpunitOptions()->willReturn([
             new PHPUnitOption('opt', false),
-            $optionWithValue
-        ));
-        
+            $optionWithValue,
+        ]);
+
         $phpunit = $this->prophesize(PHPUnitBinFile::class);
 
         $cli = new CommandLine($phpunit->reveal());
         $options = $cli->getOptions($config->reveal());
-        $this->assertTrue(is_array($options), 'Expecting an array, got ' . gettype($options));
+        $this->assertInternalType('array', $options, 'Expecting an array, got ' . gettype($options));
         $this->assertContains('--configuration=/path/to/phpunit.xml', $options);
         $this->assertContains('--printer=' . LogPrinter::class, $options);
         $this->assertContains('--opt', $options);

--- a/tests/Unit/Process/CommandLineWithCoverageTest.php
+++ b/tests/Unit/Process/CommandLineWithCoverageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Process;
@@ -66,7 +67,7 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
         $config->getPhpunitOptions()
             ->willReturn([
                 new PHPUnitOption('opt', false),
-                $optionWithValue
+                $optionWithValue,
             ]);
 
         $phpDbg = $this->prophesize(PHPDbgBinFile::class);
@@ -78,12 +79,11 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
         $phpunit = $this->prophesize(PHPUnitBinFile::class);
         $fileNameFactory = $this->prophesize(TempFilenameFactory::class);
 
-
         $cli = new CommandLineWithCoverage($phpunit->reveal(), $phpDbg->reveal(), $fileNameFactory->reveal());
 
         $options = $cli->getOptions($config->reveal());
 
-        $this->assertTrue(is_array($options), 'Expecting an array, got ' . gettype($options));
+        $this->assertInternalType('array', $options, 'Expecting an array, got ' . gettype($options));
         $this->assertContains('--configuration=/path/to/phpunit.xml', $options);
         $this->assertContains('--printer=' . LogPrinter::class, $options);
         $this->assertContains('--opt', $options);
@@ -110,7 +110,7 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
 
         $options = $cli->getOptions($config->reveal());
 
-        $this->assertTrue(is_array($options), 'Expecting an array, got ' . gettype($options));
+        $this->assertInternalType('array', $options, 'Expecting an array, got ' . gettype($options));
         $this->assertContains('-qrr', $options);
         $this->assertEquals('-qrr', $options[0], '-qrr option needs to be the first one!');
         $this->assertContains('path/to/phpunit', $options);
@@ -135,7 +135,7 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
 
         $options = $cli->getSpecificOptions($testFilename);
 
-        $this->assertTrue(is_array($options), 'Expecting an array, got ' . gettype($options));
+        $this->assertInternalType('array', $options, 'Expecting an array, got ' . gettype($options));
         $this->assertContains('--coverage-php=/path/to/coverage.php', $options);
     }
 }

--- a/tests/Unit/Process/ProcessBuilderFactoryTest.php
+++ b/tests/Unit/Process/ProcessBuilderFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Process;

--- a/tests/Unit/Process/SymfonyProcessWrapperTest.php
+++ b/tests/Unit/Process/SymfonyProcessWrapperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Process;
@@ -6,9 +7,9 @@ namespace Tests\Unit\Process;
 use Paraunit\Configuration\EnvVariables;
 use Paraunit\Process\SymfonyProcessWrapper;
 use Prophecy\Argument;
-use Tests\BaseUnitTestCase;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
+use Tests\BaseUnitTestCase;
 
 /**
  * Class SymfonyProcessWrapperTest

--- a/tests/Unit/Runner/PipelineCollectionTest.php
+++ b/tests/Unit/Runner/PipelineCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Runner;
@@ -19,13 +20,13 @@ class PipelineCollectionTest extends BaseUnitTestCase
 {
     public function testInstantiation()
     {
-        $pipelines = array(
+        $pipelines = [
             $this->prophesize(Pipeline::class)->reveal(),
             $this->prophesize(Pipeline::class)->reveal(),
             $this->prophesize(Pipeline::class)->reveal(),
             $this->prophesize(Pipeline::class)->reveal(),
             $this->prophesize(Pipeline::class)->reveal(),
-        );
+        ];
 
         new PipelineCollection($this->mockPipelineFactory($pipelines), count($pipelines));
     }

--- a/tests/Unit/Runner/PipelineFactoryTest.php
+++ b/tests/Unit/Runner/PipelineFactoryTest.php
@@ -1,12 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Runner;
 
 use Paraunit\Runner\Pipeline;
 use Paraunit\Runner\PipelineFactory;
-use Tests\BaseUnitTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Tests\BaseUnitTestCase;
 
 /**
  * Class PipelineFactoryTest

--- a/tests/Unit/Runner/PipelineTest.php
+++ b/tests/Unit/Runner/PipelineTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\Runner;

--- a/tests/Unit/Runner/RunnerTest.php
+++ b/tests/Unit/Runner/RunnerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Runner;
 
 use Paraunit\Filter\Filter;
@@ -78,7 +80,7 @@ class RunnerTest extends BaseUnitTestCase
         $eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
         $eventDispatcher->dispatch(Argument::cetera())
             ->shouldNotBeCalled();
-        
+
         $filter = $this->prophesize(Filter::class);
         $filter->filterTestFiles()
             ->willReturn([]);
@@ -107,7 +109,7 @@ class RunnerTest extends BaseUnitTestCase
         $eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
         $eventDispatcher->dispatch(ProcessEvent::PROCESS_TO_BE_RETRIED, Argument::type(ProcessEvent::class))
             ->shouldBeCalledTimes(1);
-        
+
         $filter = $this->prophesize(Filter::class);
         $filter->filterTestFiles()
             ->willReturn([]);
@@ -156,7 +158,7 @@ class RunnerTest extends BaseUnitTestCase
     private function mockProcessBuilder(): ProcessBuilder
     {
         $processBuilder = $this->prophesize(ProcessBuilder::class);
-        
+
         return $processBuilder->reveal();
     }
 }

--- a/tests/Unit/TestResult/TestResultContainerTest.php
+++ b/tests/Unit/TestResult/TestResultContainerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\TestResult;

--- a/tests/Unit/TestResult/TestResultFactoryTest.php
+++ b/tests/Unit/TestResult/TestResultFactoryTest.php
@@ -1,17 +1,18 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\TestResult;
 
 use Paraunit\Parser\JSON\LogFetcher;
+use Paraunit\TestResult\FullTestResult;
+use Paraunit\TestResult\MuteTestResult;
 use Paraunit\TestResult\TestResultFactory;
 use Paraunit\TestResult\TestResultFormat;
-use Tests\BaseUnitTestCase;
-use Paraunit\TestResult\MuteTestResult;
-use Paraunit\TestResult\TestResultWithMessage;
-use Paraunit\TestResult\FullTestResult;
-use Paraunit\TestResult\TraceStep;
 use Paraunit\TestResult\TestResultWithAbnormalTermination;
+use Paraunit\TestResult\TestResultWithMessage;
+use Paraunit\TestResult\TraceStep;
+use Tests\BaseUnitTestCase;
 
 /**
  * Class TestResultFactoryTest

--- a/tests/Unit/TestResult/TraceStepTest.php
+++ b/tests/Unit/TestResult/TraceStepTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Tests\Unit\TestResult;


### PR DESCRIPTION
This PR addresses #110 and replaces PHPCodeSniffer with the facile-it code style package, which uses PHP-CS-Fixer.