### PR TITLE
Fix text options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,10 @@ jobs:
     - stage: Code style, static analysis and E2E
       env: E2E=true
       install: composer install --no-dev --no-interaction
-      script: src/Paraunit/Bin/paraunit run nothing
+      script: 
+        - src/Paraunit/Bin/paraunit run FakeDriverTest
+        - src/Paraunit/Bin/paraunit coverage FakeDriverTest --text
+        - src/Paraunit/Bin/paraunit coverage FakeDriverTest --summary-text
     - env: PHPSTAN=true
       script: composer phpstan
     - env: CS-FIXER=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 
 before_install: 
   - if [[ !$XDEBUG ]]; then phpenv config-rm xdebug.ini; fi
-  - composer config -g github-oauth.github.com $GITHUB_API_KEY
+  - if [ -n "$GITHUB_API_KEY" ]; then composer config -g github-oauth.github.com ${GITHUB_API_KEY}; fi;
 
 install: composer update --prefer-dist --prefer-stable --no-interaction
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       script: 
         - src/Paraunit/Bin/paraunit run FakeDriverTest
         - src/Paraunit/Bin/paraunit coverage FakeDriverTest --text
-        - src/Paraunit/Bin/paraunit coverage FakeDriverTest --summary-text
+        - src/Paraunit/Bin/paraunit coverage FakeDriverTest --text-summary
     - env: PHPSTAN=true
       script: composer phpstan
     - env: CS-FIXER=true

--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## Unreleased
+
+## [0.12] - 2018-04-06
+### Fixed
+ * Fix the behavior of the new `--text` and `--text-summary` options [#121](https://github.com/facile-it/paraunit/pull/121)
 
 ## [0.12] - 2018-04-05
 ### Added

--- a/src/Paraunit/Command/CoverageCommand.php
+++ b/src/Paraunit/Command/CoverageCommand.php
@@ -81,7 +81,7 @@ class CoverageCommand extends ParallelCommand
     private function hasChosenCoverageMethod(InputInterface $input): bool
     {
         foreach ($this->coverageMethods as $coverageMethod) {
-            if ($input->getOption($coverageMethod)) {
+            if ($input->getOption($coverageMethod) || $input->hasParameterOption($coverageMethod)) {
                 return true;
             }
         }

--- a/src/Paraunit/Command/CoverageCommand.php
+++ b/src/Paraunit/Command/CoverageCommand.php
@@ -52,8 +52,8 @@ class CoverageCommand extends ParallelCommand
         $this->addOption(Clover::getConsoleOptionName(), null, InputOption::VALUE_REQUIRED, 'Output file for Clover XML coverage result');
         $this->addOption(Xml::getConsoleOptionName(), null, InputOption::VALUE_REQUIRED, 'Output dir for PHPUnit XML coverage result');
         $this->addOption(Html::getConsoleOptionName(), null, InputOption::VALUE_REQUIRED, 'Output dir for HTML coverage result');
-        $this->addOption(Text::getConsoleOptionName(), null, InputOption::VALUE_OPTIONAL, 'Output coverage as text into file, by default into console');
-        $this->addOption(TextSummary::getConsoleOptionName(), null, InputOption::VALUE_OPTIONAL, 'Output text coverage summary only');
+        $this->addOption(Text::getConsoleOptionName(), null, InputOption::VALUE_OPTIONAL, 'Output coverage as text into file, by default into console', false);
+        $this->addOption(TextSummary::getConsoleOptionName(), null, InputOption::VALUE_OPTIONAL, 'Output text coverage summary only', false);
         $this->addOption(Crap4j::getConsoleOptionName(), null, InputOption::VALUE_REQUIRED, 'Output file for Crap4j coverage result');
         $this->addOption(Php::getConsoleOptionName(), null, InputOption::VALUE_REQUIRED, 'Output file for PHP coverage result');
     }
@@ -81,7 +81,7 @@ class CoverageCommand extends ParallelCommand
     private function hasChosenCoverageMethod(InputInterface $input): bool
     {
         foreach ($this->coverageMethods as $coverageMethod) {
-            if ($input->getOption($coverageMethod) || $input->hasParameterOption($coverageMethod)) {
+            if ($input->hasParameterOption('--' . $coverageMethod)) {
                 return true;
             }
         }

--- a/src/Paraunit/Configuration/CoverageConfiguration.php
+++ b/src/Paraunit/Configuration/CoverageConfiguration.php
@@ -32,7 +32,7 @@ class CoverageConfiguration extends ParallelConfiguration
         $this->containerDefinition = new CoverageContainerDefinition();
     }
 
-    protected function loadCommandLineOptions(ContainerBuilder $container, InputInterface $input)
+    protected function loadCommandLineOptions(ContainerBuilder $container, InputInterface $input): void
     {
         parent::loadCommandLineOptions($container, $input);
 
@@ -48,7 +48,7 @@ class CoverageConfiguration extends ParallelConfiguration
         $this->addFileProcessor($coverageResult, $input, Php::class);
     }
 
-    private function addProcessor(Definition $coverageResult, string $processorClass, array $dependencies)
+    private function addProcessor(Definition $coverageResult, string $processorClass, array $dependencies): void
     {
         $coverageResult->addMethodCall('addCoverageProcessor', [new Definition($processorClass, $dependencies)]);
     }
@@ -57,7 +57,7 @@ class CoverageConfiguration extends ParallelConfiguration
         Definition $coverageResult,
         InputInterface $input,
         string $processorClass
-    ) {
+    ): void {
         $optionName = $this->getOptionName($processorClass);
 
         if ($input->getOption($optionName)) {
@@ -72,7 +72,7 @@ class CoverageConfiguration extends ParallelConfiguration
         Definition $coverageResult,
         InputInterface $input,
         string $processorClass
-    ) {
+    ): void {
         $optionName = $this->getOptionName($processorClass);
 
         if ($this->optionIsEnabled($input, $optionName)) {
@@ -88,33 +88,23 @@ class CoverageConfiguration extends ParallelConfiguration
         Definition $coverageResult,
         InputInterface $input,
         string $processorClass
-    ) {
+    ): void {
         $optionName = $this->getOptionName($processorClass);
 
         if ($this->optionIsEnabled($input, $optionName)) {
             $this->addProcessor($coverageResult, $processorClass, [
-                $this->createOutputPathDefinition($input, $optionName),
+                new Definition(OutputPath::class, [$input->getOption($optionName)]),
             ]);
         }
     }
 
-    /**
-     * @param InputInterface $input
-     * @param string $optionName
-     * @return null|Definition
-     */
-    private function createOutputFileDefinition(InputInterface $input, string $optionName)
+    private function createOutputFileDefinition(InputInterface $input, string $optionName): ?Definition
     {
-        if ($this->optionIsEnabled($input, $optionName)) {
+        if ($input->getOption($optionName)) {
             return new Definition(OutputFile::class, [$input->getOption($optionName)]);
         }
 
         return null;
-    }
-
-    private function createOutputPathDefinition(InputInterface $input, string $optionName): Definition
-    {
-        return new Definition(OutputPath::class, [$input->getOption($optionName)]);
     }
 
     /**

--- a/src/Paraunit/Configuration/ParallelConfiguration.php
+++ b/src/Paraunit/Configuration/ParallelConfiguration.php
@@ -74,7 +74,7 @@ class ParallelConfiguration
         }
     }
 
-    protected function loadCommandLineOptions(ContainerBuilder $containerBuilder, InputInterface $input)
+    protected function loadCommandLineOptions(ContainerBuilder $containerBuilder, InputInterface $input): void
     {
         $containerBuilder->setParameter('paraunit.max_process_count', $input->getOption('parallel'));
         $containerBuilder->setParameter('paraunit.phpunit_config_filename', $input->getOption('configuration') ?? '.');

--- a/tests/Functional/Command/CoverageCommandTest.php
+++ b/tests/Functional/Command/CoverageCommandTest.php
@@ -9,32 +9,109 @@ use Paraunit\Configuration\CoverageConfiguration;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\BaseTestCase;
+use Tests\Stub\StubbedParaunitProcess;
 
 class CoverageCommandTest extends BaseTestCase
 {
-    public function testExecutionWithTextToFile()
-    {
-        $coverageFileName = tempnam(sys_get_temp_dir(), 'coverage.txt');
-        $configurationPath = $this->getConfigForStubs();
-        $application = new Application();
-        $application->add(new CoverageCommand(new CoverageConfiguration()));
+    private const COMMAND_NAME = 'coverage';
 
-        $command = $application->find('coverage');
-        $commandTester = new CommandTester($command);
-        $exitCode = $commandTester->execute([
-            'command' => $command->getName(),
-            '--configuration' => $configurationPath,
+    public function testExecutionWithTextToFile(): void
+    {
+        $coverageFileName = $this->getTempCoverageFilename();
+        $commandTester = $this->createCommandTester();
+
+        $arguments = $this->prepareArguments([
             '--text' => $coverageFileName,
-            'stringFilter' => 'green',
         ]);
+        $exitCode = $commandTester->execute($arguments);
 
         $output = $commandTester->getDisplay();
         $this->assertNotContains('NO TESTS EXECUTED', $output);
         $this->assertNotContains('Coverage Report', $output);
+        $this->assertNotContains(StubbedParaunitProcess::class, $output);
         $this->assertEquals(0, $exitCode);
         $this->assertFileExists($coverageFileName);
         $fileContent = file_get_contents($coverageFileName);
         unlink($coverageFileName);
         $this->assertContains('Coverage Report', $fileContent);
+        $this->assertContains(StubbedParaunitProcess::class, $fileContent);
+    }
+
+    public function testExecutionWithTextToConsole(): void
+    {
+        $commandTester = $this->createCommandTester();
+
+        $arguments = $this->prepareArguments([
+            '--text' => null,
+        ]);
+        $exitCode = $commandTester->execute($arguments);
+
+        $output = $commandTester->getDisplay();
+        $this->assertNotContains('NO TESTS EXECUTED', $output);
+        $this->assertContains('Coverage Report', $output);
+        $this->assertContains(StubbedParaunitProcess::class, $output);
+        $this->assertEquals(0, $exitCode);
+    }
+
+    public function testExecutionWithTextSummaryToFile(): void
+    {
+        $coverageFileName = $this->getTempCoverageFilename();
+        $commandTester = $this->createCommandTester();
+
+        $arguments = $this->prepareArguments([
+            '--text-summary' => $coverageFileName,
+        ]);
+        $exitCode = $commandTester->execute($arguments);
+
+        $output = $commandTester->getDisplay();
+        $this->assertNotContains('NO TESTS EXECUTED', $output);
+        $this->assertNotContains('Coverage Report', $output);
+        $this->assertNotContains(StubbedParaunitProcess::class, $output);
+        $this->assertEquals(0, $exitCode);
+        $this->assertFileExists($coverageFileName);
+        $fileContent = file_get_contents($coverageFileName);
+        unlink($coverageFileName);
+        $this->assertContains('Coverage Report', $fileContent);
+        $this->assertNotContains(StubbedParaunitProcess::class, $fileContent);
+    }
+
+    public function testExecutionWithTextSummaryToConsole(): void
+    {
+        $commandTester = $this->createCommandTester();
+
+        $arguments = $this->prepareArguments([
+            '--text-summary' => null,
+        ]);
+        $exitCode = $commandTester->execute($arguments);
+
+        $output = $commandTester->getDisplay();
+        $this->assertNotContains('NO TESTS EXECUTED', $output);
+        $this->assertContains('Coverage Report', $output);
+        $this->assertNotContains(StubbedParaunitProcess::class, $output);
+        $this->assertEquals(0, $exitCode);
+    }
+
+    private function getTempCoverageFilename(): string
+    {
+        return tempnam(sys_get_temp_dir(), 'coverage.txt');
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        $application = new Application();
+        $application->add(new CoverageCommand(new CoverageConfiguration()));
+
+        $command = $application->find(self::COMMAND_NAME);
+
+        return new CommandTester($command);
+    }
+
+    private function prepareArguments(array $additionalArguments = []): array
+    {
+        return array_merge([
+            'command' => self::COMMAND_NAME,
+            '--configuration' => $this->getConfigForStubs(),
+            'stringFilter' => 'green',
+        ], $additionalArguments);
     }
 }

--- a/tests/Functional/Command/CoverageCommandTest.php
+++ b/tests/Functional/Command/CoverageCommandTest.php
@@ -9,7 +9,6 @@ use Paraunit\Configuration\CoverageConfiguration;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Tests\BaseTestCase;
-use Tests\Stub\StubbedParaunitProcess;
 
 class CoverageCommandTest extends BaseTestCase
 {
@@ -28,13 +27,13 @@ class CoverageCommandTest extends BaseTestCase
         $output = $commandTester->getDisplay();
         $this->assertNotContains('NO TESTS EXECUTED', $output);
         $this->assertNotContains('Coverage Report', $output);
-        $this->assertNotContains(StubbedParaunitProcess::class, $output);
+        $this->assertNotContains('StubbedParaunitProcess', $output);
         $this->assertEquals(0, $exitCode);
         $this->assertFileExists($coverageFileName);
         $fileContent = file_get_contents($coverageFileName);
         unlink($coverageFileName);
         $this->assertContains('Coverage Report', $fileContent);
-        $this->assertContains(StubbedParaunitProcess::class, $fileContent);
+        $this->assertContains('StubbedParaunitProcess', $fileContent);
     }
 
     public function testExecutionWithTextToConsole(): void
@@ -49,7 +48,7 @@ class CoverageCommandTest extends BaseTestCase
         $output = $commandTester->getDisplay();
         $this->assertNotContains('NO TESTS EXECUTED', $output);
         $this->assertContains('Coverage Report', $output);
-        $this->assertContains(StubbedParaunitProcess::class, $output);
+        $this->assertContains('StubbedParaunitProcess', $output);
         $this->assertEquals(0, $exitCode);
     }
 
@@ -66,13 +65,13 @@ class CoverageCommandTest extends BaseTestCase
         $output = $commandTester->getDisplay();
         $this->assertNotContains('NO TESTS EXECUTED', $output);
         $this->assertNotContains('Coverage Report', $output);
-        $this->assertNotContains(StubbedParaunitProcess::class, $output);
+        $this->assertNotContains('StubbedParaunitProcess', $output);
         $this->assertEquals(0, $exitCode);
         $this->assertFileExists($coverageFileName);
         $fileContent = file_get_contents($coverageFileName);
         unlink($coverageFileName);
         $this->assertContains('Coverage Report', $fileContent);
-        $this->assertNotContains(StubbedParaunitProcess::class, $fileContent);
+        $this->assertNotContains('StubbedParaunitProcess', $fileContent);
     }
 
     public function testExecutionWithTextSummaryToConsole(): void
@@ -87,7 +86,7 @@ class CoverageCommandTest extends BaseTestCase
         $output = $commandTester->getDisplay();
         $this->assertNotContains('NO TESTS EXECUTED', $output);
         $this->assertContains('Coverage Report', $output);
-        $this->assertNotContains(StubbedParaunitProcess::class, $output);
+        $this->assertNotContains('StubbedParaunitProcess', $output);
         $this->assertEquals(0, $exitCode);
     }
 

--- a/tests/Stub/ThreeGreenTestStub.php
+++ b/tests/Stub/ThreeGreenTestStub.php
@@ -12,17 +12,19 @@ use PHPUnit\Framework\TestCase;
  */
 class ThreeGreenTestStub extends TestCase
 {
-    public function testGreenOne()
+    public function testGreenOne(): void
+    {
+        $process = new StubbedParaunitProcess();
+
+        $this->assertTrue($process->isTerminated());
+    }
+
+    public function testGreenTwo(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testGreenTwo()
-    {
-        $this->assertTrue(true);
-    }
-
-    public function testGreenThree()
+    public function testGreenThree(): void
     {
         $this->assertTrue(true);
     }

--- a/tests/Stub/phpunit_for_stubs.xml
+++ b/tests/Stub/phpunit_for_stubs.xml
@@ -1,5 +1,5 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="../../vendor/autoload.php"
@@ -19,7 +19,7 @@
 
     <filter>
         <whitelist>
-            <directory>./*</directory>
+            <file>StubbedParaunitProcess.php</file>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
This PR attempts to fix a bug introduced with the new changes of the 0.12 release. Using input options with optional arguments it's really tricky with `symfony/console`!

I'm using a solution found in https://github.com/symfony/symfony/issues/11572#issuecomment-197929086