### PR TITLE
Avoid letting the colored console output blink (dots, errors)

### DIFF
--- a/src/Paraunit/Printer/ConsoleFormatter.php
+++ b/src/Paraunit/Printer/ConsoleFormatter.php
@@ -38,6 +38,6 @@ class ConsoleFormatter extends AbstractPrinter implements EventSubscriberInterfa
 
     private function createNewStyle(string $color): OutputFormatterStyle
     {
-        return new OutputFormatterStyle($color, null, ['bold', 'blink']);
+        return new OutputFormatterStyle($color, null, ['bold']);
     }
 }


### PR DESCRIPTION
On bash 4.4.19 (Fedora 28) the text started blinking. Looking into the ConsoleFormatter I've noticed it's set to blink, but evidently for a bash bug (?) it wasn't and the output was looking good.

This pull request fixes this issue.