### PR TITLE
Add retry for mysql savepoint

### DIFF
--- a/src/Paraunit/Parser/JSON/RetryParser.php
+++ b/src/Paraunit/Parser/JSON/RetryParser.php
@@ -38,6 +38,7 @@ class RetryParser
             // MySQL
             'Deadlock found',
             'Lock wait timeout exceeded',
+            'SAVEPOINT \w+ does not exist',
             // SQLite
             'General error: 5 database is locked',
         ];

--- a/tests/Functional/Command/ParallelCommandTest.php
+++ b/tests/Functional/Command/ParallelCommandTest.php
@@ -87,7 +87,7 @@ class ParallelCommandTest extends BaseTestCase
         $this->assertContains(MySQLDeadLockTestStub::class, $output);
         $this->assertNotEquals(0, $exitCode);
 
-        $this->assertContains('Executed: 12 test classes (15 retried), 22 tests', $output);
+        $this->assertContains('Executed: 13 test classes (18 retried), 23 tests', $output);
     }
 
     public function testExecutionWithLogo()
@@ -125,11 +125,11 @@ class ParallelCommandTest extends BaseTestCase
         $output = $commandTester->getDisplay();
         $this->assertNotEquals(0, $exitCode);
 
-        $classExecuted = 12;
-        $processRetried = 15;
+        $classExecuted = 13;
+        $processRetried = 18;
         $processesCount = $classExecuted + $processRetried;
         $this->assertContains(
-            sprintf('Executed: %d test classes (%d retried), 22 tests', $classExecuted, $processRetried),
+            sprintf('Executed: %d test classes (%d retried), 23 tests', $classExecuted, $processRetried),
             $output,
             'Precondition failed'
         );

--- a/tests/Stub/MySQLSavePointMissingTestStub.php
+++ b/tests/Stub/MySQLSavePointMissingTestStub.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stub;
+
+/**
+ * Class MySQLSavePointMissingTestStub
+ * @package Tests\Stub
+ */
+class MySQLSavePointMissingTestStub extends BrokenTestBase implements BrokenTestInterface
+{
+    const OUTPUT = 'SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT DOCTRINE2_SAVEPOINT_2 does not exist';
+
+    /**
+     * @throws \Exception
+     */
+    public function testBrokenTest()
+    {
+        throw new \Exception(self::OUTPUT);
+    }
+}

--- a/tests/Unit/Parser/JSON/RetryParserTest.php
+++ b/tests/Unit/Parser/JSON/RetryParserTest.php
@@ -11,6 +11,7 @@ use Tests\BaseUnitTestCase;
 use Tests\Stub\EntityManagerClosedTestStub;
 use Tests\Stub\MySQLDeadLockTestStub;
 use Tests\Stub\MySQLLockTimeoutTestStub;
+use Tests\Stub\MySQLSavePointMissingTestStub;
 use Tests\Stub\PHPUnitJSONLogOutput\JSONLogStub;
 use Tests\Stub\SQLiteDeadLockTestStub;
 use Tests\Stub\StubbedParaunitProcess;
@@ -70,6 +71,7 @@ class RetryParserTest extends BaseUnitTestCase
             [EntityManagerClosedTestStub::OUTPUT],
             [MySQLDeadLockTestStub::OUTPUT],
             [MySQLLockTimeoutTestStub::OUTPUT],
+            [MySQLSavePointMissingTestStub::OUTPUT],
             [SQLiteDeadLockTestStub::OUTPUT],
         ];
     }


### PR DESCRIPTION
I've discovered that, when using the DBMS savepoints during parallel tests (like when using dama/doctrine-test-bundle), we can encounter a new kind of exception. 

This adds this exception to the retryable ones.