### PR TITLE
Options without value are not working!

### DIFF
--- a/src/Paraunit/Command/ParallelCommand.php
+++ b/src/Paraunit/Command/ParallelCommand.php
@@ -112,10 +112,13 @@ class ParallelCommand extends Command
     {
         foreach ($this->phpunitOptions as $option) {
             $cliOption = $input->getOption($option->getName());
-            if ($cliOption) {
-                $option->setValue($cliOption);
-                $config->addPhpunitOption($option);
+            if (! $cliOption) {
+                continue;
             }
+            if ($option->hasValue()) {
+                $option->setValue($cliOption);
+            }
+            $config->addPhpunitOption($option);
         }
 
         return $config;

--- a/src/Paraunit/Command/ParallelCommand.php
+++ b/src/Paraunit/Command/ParallelCommand.php
@@ -108,6 +108,11 @@ class ParallelCommand extends Command
         return $runner->run();
     }
 
+    /**
+     * @param PHPUnitConfig $config
+     * @param InputInterface $input
+     * @return PHPUnitConfig
+     */
     private function addPHPUnitOptions(PHPUnitConfig $config, InputInterface $input): PHPUnitConfig
     {
         foreach ($this->phpunitOptions as $option) {

--- a/src/Paraunit/Command/ParallelCommand.php
+++ b/src/Paraunit/Command/ParallelCommand.php
@@ -127,7 +127,7 @@ class ParallelCommand extends Command
 
     /**
      * @param PHPUnitOption $option
-     * @param $cliOption
+     * @param mixed $cliOption
      * @return bool
      */
     private function setOptionValue(PHPUnitOption $option, $cliOption): bool

--- a/src/Paraunit/Command/ParallelCommand.php
+++ b/src/Paraunit/Command/ParallelCommand.php
@@ -117,15 +117,28 @@ class ParallelCommand extends Command
     {
         foreach ($this->phpunitOptions as $option) {
             $cliOption = $input->getOption($option->getName());
-            if (! $cliOption) {
-                continue;
+            if ($this->setOptionValue($option, $cliOption)) {
+                $config->addPhpunitOption($option);
             }
-            if ($option->hasValue()) {
-                $option->setValue($cliOption);
-            }
-            $config->addPhpunitOption($option);
         }
 
         return $config;
+    }
+
+    /**
+     * @param PHPUnitOption $option
+     * @param $cliOption
+     * @return bool
+     */
+    private function setOptionValue(PHPUnitOption $option, $cliOption): bool
+    {
+        if (! $cliOption) {
+            return false;
+        }
+        if ($option->hasValue()) {
+            $option->setValue($cliOption);
+        }
+
+        return true;
     }
 }

--- a/tests/Functional/Command/ParallelCommandTest.php
+++ b/tests/Functional/Command/ParallelCommandTest.php
@@ -139,6 +139,24 @@ class ParallelCommandTest extends BaseTestCase
         $this->assertSame($processRetried, substr_count($output, 'PROCESS TO BE RETRIED'));
     }
 
+    public function testExecutionWithParametersWithoutValue()
+    {
+        $configurationPath = $this->getConfigForStubs();
+        $application = new Application();
+        $application->add(new ParallelCommand(new ParallelConfiguration()));
+
+        $command = $application->find('run');
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute([
+            'command' => $command->getName(),
+            '--configuration' => $configurationPath,
+            'stringFilter' => 'green',
+            '--dont-report-useless-tests' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+    }
+
     public function testExecutionWithoutConfiguration()
     {
         $application = new Application();


### PR DESCRIPTION
If a parameter without value (like --dont-report-useless-tests) is given, its value should not be passed to phpunit