### PR TITLE
Update PHPStan to 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1
@@ -24,10 +25,8 @@ jobs:
       env: XDEBUG=true
     - name: Prefer lowest
       php: 7.1
-      env:
-        VENDOR: prefer-lowest
       install: composer update --prefer-lowest --prefer-dist --prefer-stable --no-interaction
-    - env: VENDOR=lock
+    - name: Use composer.lock
       php: 7.2
       install: composer install --prefer-dist --no-interaction
     - stage: Code style, static analysis and E2E

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ First stable release. The following changes are in comparison to the previous, u
  * Scalar and return types added everywhere possible
 
 ### Added
+ * Add support for PHP 7.4
  * Add support for `phpunit/phpunit` 8 and `phpunit/php-code-coverage` 7 [#133](https://github.com/facile-it/paraunit/pull/133)
  * Add explicit requirement for `ext-dom` and `ext-json` [#134](https://github.com/facile-it/paraunit/pull/134)
 
@@ -23,6 +24,6 @@ First stable release. The following changes are in comparison to the previous, u
  * Do not set values on PHPUnit options that do not expect values [#127](https://github.com/facile-it/paraunit/pull/127), thanks @fullbl
 
 ### Changed
- * Update PHPStan to 0.11 [#128](https://github.com/facile-it/paraunit/pull/128)
+ * Update PHPStan to 0.12 [#128](https://github.com/facile-it/paraunit/pull/128), [#145](https://github.com/facile-it/paraunit/pull/145)
  * Update coding standard to 0.3 [#131](https://github.com/facile-it/paraunit/pull/131)
  * Disable Scrutinizer [#132](https://github.com/facile-it/paraunit/pull/132)

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         }
     },
     "scripts": {
-        "phpstan": "phpstan analyse src tests -c phpstan.neon -l 7",
+        "phpstan": "phpstan analyse src tests -c phpstan.neon -l 8",
         "cs-check": "php -n bin/php-cs-fixer fix --dry-run --diff",
         "cs-fix": "php -n bin/php-cs-fixer fix"
     },

--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
     },
     "require-dev": {
         "facile-it/facile-coding-standard": "^0.3.1",
-        "jangregor/phpstan-prophecy": "^0.4.2",
+        "jangregor/phpstan-prophecy": "^0.6.0",
         "php-coveralls/php-coveralls": "^2.0",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "^0.11",
-        "phpstan/phpstan-phpunit": "^0.11",
+        "phpstan/phpstan": "^0.12.4",
+        "phpstan/phpstan-phpunit": "^0.12.5",
         "phpunit/php-invoker": "^1.1",
         "symfony/expression-language": "^3.4||^4.0",
         "symfony/phpunit-bridge": "^4.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0edb73e11203d5a06fa69bb4357886f",
+    "content-hash": "c6972fd170c4b3fc41b78ea03ae09b57",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -2738,29 +2738,29 @@
         },
         {
             "name": "jangregor/phpstan-prophecy",
-            "version": "0.4.2",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Jan0707/phpstan-prophecy.git",
-                "reference": "23301ff577da974e47e8670bf9313c885d306011"
+                "reference": "542c8ed7228af772562fb0f370d15ec73e3bdecf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Jan0707/phpstan-prophecy/zipball/23301ff577da974e47e8670bf9313c885d306011",
-                "reference": "23301ff577da974e47e8670bf9313c885d306011",
+                "url": "https://api.github.com/repos/Jan0707/phpstan-prophecy/zipball/542c8ed7228af772562fb0f370d15ec73e3bdecf",
+                "reference": "542c8ed7228af772562fb0f370d15ec73e3bdecf",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1",
-                "phpstan/phpstan": "^0.10.0 || ^0.11.0"
+                "phpstan/phpstan": "^0.12.0"
             },
             "conflict": {
                 "phpspec/prophecy": "<1.7,>=2.0",
                 "phpunit/phpunit": "<6.0,>=9.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.15.0",
-                "localheinz/composer-normalize": "^1.1.3",
+                "ergebnis/composer-normalize": "^2.1.1",
+                "ergebnis/php-cs-fixer-config": "~1.1.2",
                 "phpspec/prophecy": "^1.7",
                 "phpunit/phpunit": "^6.0 || ^7.0"
             },
@@ -2770,6 +2770,11 @@
                     "includes": [
                         "src/extension.neon"
                     ]
+                },
+                "violinist": {
+                    "allow_updates_beyond_constraint": 0,
+                    "one_pull_request_per_package": 1,
+                    "update_with_dependencies": 1
                 }
             },
             "autoload": {
@@ -2788,591 +2793,7 @@
                 }
             ],
             "description": "Provides a phpstan/phpstan extension for phpspec/prophecy",
-            "time": "2019-07-31T13:51:23+00:00"
-        },
-        {
-            "name": "nette/bootstrap",
-            "version": "v3.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/bootstrap.git",
-                "reference": "b45a1e33b6a44beb307756522396551e5a9ff249"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/bootstrap/zipball/b45a1e33b6a44beb307756522396551e5a9ff249",
-                "reference": "b45a1e33b6a44beb307756522396551e5a9ff249",
-                "shasum": ""
-            },
-            "require": {
-                "nette/di": "^3.0",
-                "nette/utils": "^3.0",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "tracy/tracy": "<2.6"
-            },
-            "require-dev": {
-                "latte/latte": "^2.2",
-                "nette/application": "^3.0",
-                "nette/caching": "^3.0",
-                "nette/database": "^3.0",
-                "nette/forms": "^3.0",
-                "nette/http": "^3.0",
-                "nette/mail": "^3.0",
-                "nette/robot-loader": "^3.0",
-                "nette/safe-stream": "^2.2",
-                "nette/security": "^3.0",
-                "nette/tester": "^2.0",
-                "tracy/tracy": "^2.6"
-            },
-            "suggest": {
-                "nette/robot-loader": "to use Configurator::createRobotLoader()",
-                "tracy/tracy": "to use Configurator::enableTracy()"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🅱 Nette Bootstrap: the simple way to configure and bootstrap your Nette application.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "bootstrapping",
-                "configurator",
-                "nette"
-            ],
-            "time": "2019-09-30T08:19:38+00:00"
-        },
-        {
-            "name": "nette/di",
-            "version": "v3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/di.git",
-                "reference": "7ae47daa94b8dafbd0e8b6164e22e2d18d3e73ac"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/di/zipball/7ae47daa94b8dafbd0e8b6164e22e2d18d3e73ac",
-                "reference": "7ae47daa94b8dafbd0e8b6164e22e2d18d3e73ac",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "nette/neon": "^3.0",
-                "nette/php-generator": "^3.3",
-                "nette/robot-loader": "^3.2",
-                "nette/schema": "^1.0",
-                "nette/utils": "^3.0",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "nette/bootstrap": "<3.0"
-            },
-            "require-dev": {
-                "nette/tester": "^2.2",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ],
-                "files": [
-                    "src/compatibility.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "💎 Nette Dependency Injection Container: Flexible, compiled and full-featured DIC with perfectly usable autowiring and support for all new PHP 7.1 features.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "compiled",
-                "di",
-                "dic",
-                "factory",
-                "ioc",
-                "nette",
-                "static"
-            ],
-            "time": "2019-12-17T04:03:21+00:00"
-        },
-        {
-            "name": "nette/finder",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/finder.git",
-                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/finder/zipball/4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
-                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^2.4 || ^3.0",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "nette/nette": "<2.2"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.5-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🔍 Nette Finder: find files and directories with an intuitive API.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "filesystem",
-                "glob",
-                "iterator",
-                "nette"
-            ],
-            "time": "2020-01-03T20:35:40+00:00"
-        },
-        {
-            "name": "nette/neon",
-            "version": "v3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/neon.git",
-                "reference": "0a18fc88801a14d66587932de133eeca01f7ce8e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/neon/zipball/0a18fc88801a14d66587932de133eeca01f7ce8e",
-                "reference": "0a18fc88801a14d66587932de133eeca01f7ce8e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "ext-json": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
-            "homepage": "http://ne-on.org",
-            "keywords": [
-                "export",
-                "import",
-                "neon",
-                "nette",
-                "yaml"
-            ],
-            "time": "2019-12-27T04:00:04+00:00"
-        },
-        {
-            "name": "nette/php-generator",
-            "version": "v3.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/php-generator.git",
-                "reference": "facde285ba959366e7eee09c7f198f2d9ef176ca"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/facde285ba959366e7eee09c7f198f2d9ef176ca",
-                "reference": "facde285ba959366e7eee09c7f198f2d9ef176ca",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^2.4.2 || ^3.0",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.4 features.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "code",
-                "nette",
-                "php",
-                "scaffolding"
-            ],
-            "time": "2020-01-03T19:49:13+00:00"
-        },
-        {
-            "name": "nette/robot-loader",
-            "version": "v3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/robot-loader.git",
-                "reference": "d2a100e1f5cab390c78bc88709abbc91249c3993"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/robot-loader/zipball/d2a100e1f5cab390c78bc88709abbc91249c3993",
-                "reference": "d2a100e1f5cab390c78bc88709abbc91249c3993",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "nette/finder": "^2.5 || ^3.0",
-                "nette/utils": "^3.0",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🍀 Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "autoload",
-                "class",
-                "interface",
-                "nette",
-                "trait"
-            ],
-            "time": "2019-12-26T22:32:02+00:00"
-        },
-        {
-            "name": "nette/schema",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/schema.git",
-                "reference": "febf71fb4052c824046f5a33f4f769a6e7fa0cb4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/febf71fb4052c824046f5a33f4f769a6e7fa0cb4",
-                "reference": "febf71fb4052c824046f5a33f4f769a6e7fa0cb4",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^3.1",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.2",
-                "phpstan/phpstan-nette": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": []
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "📐 Nette Schema: validating data structures against a given Schema.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "config",
-                "nette"
-            ],
-            "time": "2020-01-06T22:52:48+00:00"
-        },
-        {
-            "name": "nette/utils",
-            "version": "v3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/utils.git",
-                "reference": "d6cd63d77dd9a85c3a2fae707e1255e44c2bc182"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/d6cd63d77dd9a85c3a2fae707e1255e44c2bc182",
-                "reference": "d6cd63d77dd9a85c3a2fae707e1255e44c2bc182",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "~2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "suggest": {
-                "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize() and toAscii()",
-                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
-                "ext-json": "to use Nette\\Utils\\Json",
-                "ext-mbstring": "to use Strings::lower() etc...",
-                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
-                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🛠 Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "array",
-                "core",
-                "datetime",
-                "images",
-                "json",
-                "nette",
-                "paginator",
-                "password",
-                "slugify",
-                "string",
-                "unicode",
-                "utf-8",
-                "utility",
-                "validation"
-            ],
-            "time": "2020-01-03T18:13:31+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "0.0.5",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "time": "2019-11-08T13:50:10+00:00"
+            "time": "2019-12-27T23:57:21+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -3598,164 +3019,80 @@
             "time": "2019-10-18T17:09:48+00:00"
         },
         {
-            "name": "phpstan/phpdoc-parser",
-            "version": "0.3.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/8c4ef2aefd9788238897b678a985e1d5c8df6db4",
-                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~7.1"
-            },
-            "require-dev": {
-                "consistence/coding-standard": "^3.5",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan": "^0.10",
-                "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2",
-                "symfony/process": "^3.4 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "time": "2019-06-07T19:13:52+00:00"
-        },
-        {
             "name": "phpstan/phpstan",
-            "version": "0.11.19",
+            "version": "0.12.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7"
+                "reference": "100a25ba8561223f6bf5a5ff4204f951c0ec007c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/63cc502f6957b7f74efbac444b4cf219dcadffd7",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/100a25ba8561223f6bf5a5ff4204f951c0ec007c",
+                "reference": "100a25ba8561223f6bf5a5ff4204f951c0ec007c",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.3.0",
-                "jean85/pretty-package-versions": "^1.0.3",
-                "nette/bootstrap": "^2.4 || ^3.0",
-                "nette/di": "^2.4.7 || ^3.0",
-                "nette/neon": "^2.4.3 || ^3.0",
-                "nette/robot-loader": "^3.0.1",
-                "nette/schema": "^1.0",
-                "nette/utils": "^2.4.5 || ^3.0",
-                "nikic/php-parser": "^4.2.3",
-                "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3.5",
-                "symfony/console": "~3.2 || ~4.0",
-                "symfony/finder": "~3.2 || ~4.0"
-            },
-            "conflict": {
-                "symfony/console": "3.4.16 || 4.1.5"
-            },
-            "require-dev": {
-                "brianium/paratest": "^2.0 || ^3.0",
-                "consistence/coding-standard": "^3.5",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-                "ext-intl": "*",
-                "ext-mysqli": "*",
-                "ext-simplexml": "*",
-                "ext-soap": "*",
-                "ext-zip": "*",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "localheinz/composer-normalize": "^1.1.0",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan-deprecation-rules": "^0.11",
-                "phpstan/phpstan-php-parser": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
-                "phpunit/phpunit": "^7.5.14 || ^8.0",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2"
+                "php": "^7.1"
             },
             "bin": [
-                "bin/phpstan"
+                "phpstan",
+                "phpstan.phar"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "PHPStan\\": [
-                        "src/"
-                    ]
-                }
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2019-10-22T20:20:22+00:00"
+            "time": "2020-01-06T06:38:17+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "0.11.2",
+            "version": "0.12.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "fbf2ad56c3b13189d29655e226c9b1da47c2fad9"
+                "reference": "26394996368b6d033d012547d3197f4e07e23021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/fbf2ad56c3b13189d29655e226c9b1da47c2fad9",
-                "reference": "fbf2ad56c3b13189d29655e226c9b1da47c2fad9",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/26394996368b6d033d012547d3197f4e07e23021",
+                "reference": "26394996368b6d033d012547d3197f4e07e23021",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
                 "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3",
-                "phpstan/phpstan": "^0.11.4"
+                "phpstan/phpstan": "^0.12.4"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.0.1",
+                "consistence/coding-standard": "^3.5",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^7.0",
                 "satooshi/php-coveralls": "^1.0",
-                "slevomat/coding-standard": "^4.5.2"
+                "slevomat/coding-standard": "^4.7.2"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -3774,7 +3111,7 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
-            "time": "2019-05-17T17:50:16+00:00"
+            "time": "2020-01-10T12:07:21+00:00"
         },
         {
             "name": "phpunit/php-invoker",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,29 @@
 parameters:
     ignoreErrors:
-        - '/does not call parent constructor from PHPUnit\\Util\\Printer/'
-        - '/Call to function method_exists.. with .Tests..BaseTestCase. and .assertStringContain.... will always evaluate to false./'
-        - '/Call to function method_exists.. with .Symfony..Component.+ and .escapeArgument. will always evaluate to false./'
+        - "#no value type specified in iterable type PHPUnit\\\\Framework\\\\TestSuite\\.$#"
+        - "#no value type specified in iterable type Symfony\\\\Component\\\\Process\\\\Process\\.$#"
+        -
+            message: "#^Method Tests\\\\Unit\\\\Configuration\\\\ParallelConfigurationTest\\:\\:getService\\(\\) has no return typehint specified\\.$#"
+            count: 1
+            path: tests/Unit/Configuration/ParallelConfigurationTest.php
+        -
+            message: "#^Method Tests\\\\Unit\\\\Configuration\\\\CoverageConfigurationTest\\:\\:getService\\(\\) has no return typehint specified\\.$#"
+            count: 1
+            path: tests/Unit/Configuration/CoverageConfigurationTest.php
+        -
+            message: "#^Method Tests\\\\BaseTestCase\\:\\:assertContains\\(\\) has parameter \\$needle with no typehint specified\\.$#"
+            count: 1
+            path: tests/BaseTestCase.php
+        
+        -
+            message: "#^Method Tests\\\\BaseTestCase\\:\\:assertNotContains\\(\\) has parameter \\$needle with no typehint specified\\.$#"
+            count: 1
+            path: tests/BaseTestCase.php
+        
+        -
+            message: "#^Method Tests\\\\Unit\\\\Configuration\\\\OutputFileTest\\:\\:testIsEmpty\\(\\) has parameter \\$emptyFile with no typehint specified\\.$#"
+            count: 1
+            path: tests/Unit/Configuration/OutputFileTest.php
     excludes_analyse:
-        - tests/Stub/ParseErrorTestStub.php
+        - tests/Stub/
         - src/Lifecycle/ForwardCompatEventDispatcher.php

--- a/src/Command/CoverageCommand.php
+++ b/src/Command/CoverageCommand.php
@@ -57,7 +57,7 @@ class CoverageCommand extends ParallelCommand
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
         if (! $this->hasChosenCoverageMethod($input)) {
-            $coverageMethods = implode($this->coverageMethods, ', ');
+            $coverageMethods = implode(', ', $this->coverageMethods);
 
             throw new \InvalidArgumentException('You should choose at least one method of coverage output between ' . $coverageMethods);
         }

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -109,6 +109,11 @@ class ParallelCommand extends Command
     {
         foreach ($this->phpunitOptions as $option) {
             $cliOption = $input->getOption($option->getName());
+
+            if (null !== $cliOption && ! \is_string($cliOption)) {
+                throw new \InvalidArgumentException('Invalid option format for CLI option ' . $option->getName());
+            }
+
             if ($this->setOptionValue($option, $cliOption)) {
                 $config->addPhpunitOption($option);
             }
@@ -117,7 +122,7 @@ class ParallelCommand extends Command
         return $config;
     }
 
-    private function setOptionValue(PHPUnitOption $option, $cliOption): bool
+    private function setOptionValue(PHPUnitOption $option, ?string $cliOption): bool
     {
         if (! $cliOption) {
             return false;

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -110,8 +110,12 @@ class ParallelCommand extends Command
         foreach ($this->phpunitOptions as $option) {
             $cliOption = $input->getOption($option->getName());
 
+            if (\is_bool($cliOption)) {
+                $cliOption = null;
+            }
+
             if (null !== $cliOption && ! \is_string($cliOption)) {
-                throw new \InvalidArgumentException('Invalid option format for CLI option ' . $option->getName());
+                throw new \InvalidArgumentException('Invalid option format for CLI option ' . $option->getName() . ': ' . gettype($cliOption));
             }
 
             if ($this->setOptionValue($option, $cliOption)) {
@@ -122,7 +126,7 @@ class ParallelCommand extends Command
         return $config;
     }
 
-    private function setOptionValue(PHPUnitOption $option, ?string $cliOption): bool
+    private function setOptionValue(PHPUnitOption $option, $cliOption): bool
     {
         if (! $cliOption) {
             return false;

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -126,7 +126,7 @@ class ParallelCommand extends Command
         return $config;
     }
 
-    private function setOptionValue(PHPUnitOption $option, $cliOption): bool
+    private function setOptionValue(PHPUnitOption $option, ?string $cliOption): bool
     {
         if (! $cliOption) {
             return false;

--- a/src/Configuration/CoverageConfiguration.php
+++ b/src/Configuration/CoverageConfiguration.php
@@ -44,6 +44,9 @@ class CoverageConfiguration extends ParallelConfiguration
         $this->addFileProcessor($coverageResult, $input, Php::class);
     }
 
+    /**
+     * @param mixed[] $dependencies
+     */
     private function addProcessor(Definition $coverageResult, string $processorClass, array $dependencies): void
     {
         $coverageResult->addMethodCall('addCoverageProcessor', [new Definition($processorClass, $dependencies)]);

--- a/src/Configuration/PHPUnitBinFile.php
+++ b/src/Configuration/PHPUnitBinFile.php
@@ -48,7 +48,7 @@ class PHPUnitBinFile
         return $this->phpUnitBin;
     }
 
-    private function setPhpUnitBin($phpUnitBin): void
+    private function setPhpUnitBin(string $phpUnitBin): void
     {
         $realpath = realpath($phpUnitBin);
         if (! $realpath) {

--- a/src/Coverage/CoverageMerger.php
+++ b/src/Coverage/CoverageMerger.php
@@ -22,6 +22,9 @@ class CoverageMerger implements EventSubscriberInterface
         $this->coverageFetcher = $coverageFetcher;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Coverage/CoverageResult.php
+++ b/src/Coverage/CoverageResult.php
@@ -22,6 +22,9 @@ class CoverageResult implements EventSubscriberInterface
         $this->coverageProcessors = [];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/File/Cleaner.php
+++ b/src/File/Cleaner.php
@@ -18,6 +18,9 @@ class Cleaner implements EventSubscriberInterface
         $this->tempDirectory = $tempDirectory;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -59,8 +59,17 @@ class Filter
         $document = $this->utilXml->loadFile($this->configFile->getFileFullPath());
         $xpath = new \DOMXPath($document);
 
-        /** @var \DOMElement $testSuiteNode */
-        foreach ($xpath->query('testsuites/testsuite') as $testSuiteNode) {
+        $nodeList = $xpath->query('testsuites/testsuite');
+
+        if (! $nodeList) {
+            throw new \InvalidArgumentException('No testsuite found in the PHPUnit configuration in ' . $this->configFile->getFileFullPath());
+        }
+
+        foreach ($nodeList as $testSuiteNode) {
+            if (! $testSuiteNode instanceof \DOMElement) {
+                throw new \InvalidArgumentException('Invalid DOM subtype in PHPUnit configuration, expeding \DOMElement, got ' . get_class($testSuiteNode));
+            }
+
             if ($this->testSuitePassFilter($testSuiteNode, $this->testSuiteFilter)) {
                 $this->addTestsFromTestSuite($testSuiteNode, $aggregatedFiles);
             }
@@ -83,6 +92,8 @@ class Filter
     }
 
     /**
+     * @param string[] $aggregatedFiles
+     *
      * @return string[]
      */
     private function addTestsFromTestSuite(\DOMElement $testSuiteNode, array &$aggregatedFiles): array
@@ -141,6 +152,9 @@ class Filter
         }
     }
 
+    /**
+     * @param string[] $aggregatedFiles
+     */
     private function addFileToAggregateArray(array &$aggregatedFiles, string $fileName): void
     {
         // optimized array_unique
@@ -162,6 +176,8 @@ class Filter
     }
 
     /**
+     * @param string[] $aggregatedFiles
+     *
      * @return string[]
      */
     private function filterByString(array $aggregatedFiles, ?string $stringFilter): array

--- a/src/Parser/DeprecationParser.php
+++ b/src/Parser/DeprecationParser.php
@@ -20,6 +20,9 @@ class DeprecationParser implements EventSubscriberInterface
         $this->testResultContainer = $testResultContainer;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Parser/JSON/LogParser.php
+++ b/src/Parser/JSON/LogParser.php
@@ -43,6 +43,9 @@ class LogParser implements EventSubscriberInterface
         $this->parsers = [];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [
@@ -97,6 +100,9 @@ class LogParser implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @param mixed[] $logs
+     */
     private function noTestsExecuted(AbstractParaunitProcess $process, array $logs): bool
     {
         return $process->getExitCode() === 0 && count($logs) === 1;

--- a/src/Parser/JSON/LogPrinter.php
+++ b/src/Parser/JSON/LogPrinter.php
@@ -201,10 +201,9 @@ class LogPrinter extends Util\Printer implements TestListener
     }
 
     /**
-     * @param string $message
      * @param Test|TestCase|null $test
      */
-    private function writeCase(string $status, float $time, string $trace, $message = '', $test = null)
+    private function writeCase(string $status, float $time, string $trace, string $message = '', $test = null): void
     {
         $output = '';
         if ($test instanceof TestCase) {
@@ -224,9 +223,9 @@ class LogPrinter extends Util\Printer implements TestListener
     }
 
     /**
-     * @param array $buffer
+     * @param (mixed|string)[] $buffer
      */
-    private function writeArray($buffer)
+    private function writeArray($buffer): void
     {
         array_walk_recursive($buffer, function (&$input) {
             if (is_string($input)) {
@@ -237,10 +236,13 @@ class LogPrinter extends Util\Printer implements TestListener
         $this->writeToLog(json_encode($buffer, JSON_PRETTY_PRINT));
     }
 
-    private function writeToLog($buffer)
+    /**
+     * @param string|false $buffer
+     */
+    private function writeToLog($buffer): void
     {
         // ignore everything that is not a JSON object
-        if ($buffer != '' && $buffer[0] === '{') {
+        if ($buffer && $buffer[0] === '{') {
             \fwrite($this->logFile, $buffer);
             \fflush($this->logFile);
         }
@@ -283,7 +285,7 @@ class LogPrinter extends Util\Printer implements TestListener
         return $logDirectory;
     }
 
-    private function convertToUtf8($string): string
+    private function convertToUtf8(string $string): string
     {
         if (! \mb_detect_encoding($string, 'UTF-8', true)) {
             return \mb_convert_encoding($string, 'UTF-8');
@@ -292,7 +294,7 @@ class LogPrinter extends Util\Printer implements TestListener
         return $string;
     }
 
-    private function getStackTrace($error): string
+    private function getStackTrace(\Throwable $error): string
     {
         return Util\Filter::getFilteredStacktrace($error);
     }

--- a/src/Parser/JSON/RetryParser.php
+++ b/src/Parser/JSON/RetryParser.php
@@ -37,6 +37,9 @@ class RetryParser
         $this->regexPattern = $this->buildRegexPattern($patterns);
     }
 
+    /**
+     * @param \stdClass[] $logs
+     */
     public function processWillBeRetried(AbstractParaunitProcess $process, array $logs): bool
     {
         if ($process->getRetryCount() >= $this->maxRetryCount) {

--- a/src/Printer/ConsoleFormatter.php
+++ b/src/Printer/ConsoleFormatter.php
@@ -10,6 +10,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ConsoleFormatter extends AbstractPrinter implements EventSubscriberInterface
 {
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Printer/CoveragePrinter.php
+++ b/src/Printer/CoveragePrinter.php
@@ -28,6 +28,9 @@ class CoveragePrinter implements EventSubscriberInterface
         $this->output = $output;
     }
 
+    /**
+     * @return array<string, (string|int)[]>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Printer/DebugPrinter.php
+++ b/src/Printer/DebugPrinter.php
@@ -12,6 +12,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class DebugPrinter extends AbstractPrinter implements EventSubscriberInterface
 {
+    /**
+     * @return array<string, string|(string|int)[]>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Printer/FailuresPrinter.php
+++ b/src/Printer/FailuresPrinter.php
@@ -13,6 +13,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class FailuresPrinter extends AbstractFinalPrinter implements EventSubscriberInterface
 {
+    /**
+     * @return array<string, (string|int)[]>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Printer/FilesRecapPrinter.php
+++ b/src/Printer/FilesRecapPrinter.php
@@ -10,6 +10,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class FilesRecapPrinter extends AbstractFinalPrinter implements EventSubscriberInterface
 {
+    /**
+     * @return array<string, (string|int)[]>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Printer/FinalPrinter.php
+++ b/src/Printer/FinalPrinter.php
@@ -37,6 +37,9 @@ class FinalPrinter extends AbstractFinalPrinter implements EventSubscriberInterf
         $this->processRetried = 0;
     }
 
+    /**
+     * @return array<string, string|(string|int)[]>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Printer/ProcessPrinter.php
+++ b/src/Printer/ProcessPrinter.php
@@ -38,6 +38,9 @@ class ProcessPrinter implements EventSubscriberInterface
         $this->singleRowCounter = 0;
     }
 
+    /**
+     * @return array<string, string|(string|int)[]>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Printer/SharkPrinter.php
+++ b/src/Printer/SharkPrinter.php
@@ -21,6 +21,9 @@ class SharkPrinter extends AbstractPrinter implements EventSubscriberInterface
         $this->showLogo = $showLogo;
     }
 
+    /**
+     * @return array<string, (string|int)[]>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Printer/SingleResultFormatter.php
+++ b/src/Printer/SingleResultFormatter.php
@@ -10,7 +10,7 @@ use Paraunit\TestResult\TestResultWithSymbolFormat;
 
 class SingleResultFormatter
 {
-    /** @var array */
+    /** @var array<string, string> */
     private $tagMap;
 
     public function __construct(TestResultList $testResultList)

--- a/src/Process/CommandLine.php
+++ b/src/Process/CommandLine.php
@@ -29,6 +29,8 @@ class CommandLine
 
     /**
      * @throws \RuntimeException When the config handling fails
+     *
+     * @return string[]
      */
     public function getOptions(PHPUnitConfig $config): array
     {

--- a/src/Process/CommandLineWithCoverage.php
+++ b/src/Process/CommandLineWithCoverage.php
@@ -44,6 +44,8 @@ class CommandLineWithCoverage extends CommandLine
 
     /**
      * @throws \RuntimeException
+     *
+     * @return string[]
      */
     public function getOptions(PHPUnitConfig $config): array
     {

--- a/src/Proxy/Coverage/FakeDriver.php
+++ b/src/Proxy/Coverage/FakeDriver.php
@@ -13,6 +13,9 @@ class FakeDriver implements Driver
         throw new \RuntimeException('This is a fake implementation, it shouldn\'t be used!');
     }
 
+    /**
+     * @return mixed[]
+     */
     public function stop(): array
     {
         throw new \RuntimeException('This is a fake implementation, it shouldn\'t be used!');

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -49,6 +49,9 @@ class Runner implements EventSubscriberInterface
         $this->exitCode = 0;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/TestResult/TestResultContainer.php
+++ b/src/TestResult/TestResultContainer.php
@@ -83,7 +83,7 @@ class TestResultContainer implements TestResultContainerInterface, TestResultHan
     private function addProcessOutputToResult(
         TestResultWithAbnormalTermination $result,
         AbstractParaunitProcess $process
-    ) {
+    ): void {
         $tag = $this->testResultFormat->getTag();
         $output = $process->getOutput() ?: sprintf('<%s><[NO OUTPUT FOUND]></%s>', $tag, $tag);
         $result->setTestOutput($output);

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -32,13 +32,21 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
     /** @var string[] */
     private $options;
 
-    protected function setup(): void
+    /**
+     * @param mixed[] $data
+     */
+    public function __construct(?string $name = null, array $data = [], string $dataName = '')
     {
-        parent::setUp();
+        parent::__construct($name, $data, $dataName);
 
         $this->configuration = new ParallelConfiguration(true);
         $this->options = [];
         $this->setOption('configuration', $this->getStubPath() . DIRECTORY_SEPARATOR . 'phpunit_for_stubs.xml');
+    }
+
+    protected function setup(): void
+    {
+        parent::setUp();
 
         $this->cleanUpTempDirForThisExecution();
     }

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -34,7 +34,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
 
     /**
      * @param mixed[] $data
-     * @param string|int $dataName
+     * @param string $dataName
      */
     public function __construct(?string $name = null, array $data = [], $dataName = '')
     {

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -32,21 +32,13 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
     /** @var string[] */
     private $options;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct($name = null, array $data = [], $dataName = '')
+    protected function setup(): void
     {
-        parent::__construct($name, $data, $dataName);
+        parent::setUp();
 
         $this->configuration = new ParallelConfiguration(true);
         $this->options = [];
         $this->setOption('configuration', $this->getStubPath() . DIRECTORY_SEPARATOR . 'phpunit_for_stubs.xml');
-    }
-
-    protected function setup(): void
-    {
-        parent::setUp();
 
         $this->cleanUpTempDirForThisExecution();
     }
@@ -79,6 +71,9 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
         }
     }
 
+    /**
+     * @param string[] $strings
+     */
     protected function assertOutputOrder(UnformattedOutputStub $output, array $strings): void
     {
         $previousPosition = 0;
@@ -143,6 +138,9 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
         return $service;
     }
 
+    /**
+     * @return int|string
+     */
     public function getParameter(string $parameterName)
     {
         if ($this->container) {

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -34,8 +34,9 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
 
     /**
      * @param mixed[] $data
+     * @param string|int $dataName
      */
-    public function __construct(?string $name = null, array $data = [], string $dataName = '')
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
     {
         parent::__construct($name, $data, $dataName);
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -87,6 +87,8 @@ class BaseTestCase extends TestCase
     /**
      * BC compat method provided as a workaround for deprecations.
      * The newer methods are present only from PHPUnit 7.5.0 onwards
+     *
+     * @param string|array<mixed>|object|\Traversable<mixed> $haystack
      */
     public static function assertContains(
         $needle,
@@ -112,6 +114,8 @@ class BaseTestCase extends TestCase
     /**
      * BC compat method provided as a workaround for deprecations.
      * The newer methods are present only from PHPUnit 7.5.0 onwards
+     *
+     * @param string|array<mixed>|object|\Traversable<mixed> $haystack
      */
     public static function assertNotContains(
         $needle,

--- a/tests/BaseUnitTestCase.php
+++ b/tests/BaseUnitTestCase.php
@@ -72,7 +72,7 @@ abstract class BaseUnitTestCase extends BaseTestCase
         return $this->prophesize(TestResultInterface::class)->reveal();
     }
 
-    protected function mockPrintableTestResult($symbol = null): PrintableTestResultInterface
+    protected function mockPrintableTestResult(string $symbol = null): PrintableTestResultInterface
     {
         if ($symbol === null) {
             $format = $this->prophesize(TestResultFormat::class);

--- a/tests/Functional/Command/CoverageCommandTest.php
+++ b/tests/Functional/Command/CoverageCommandTest.php
@@ -32,6 +32,7 @@ class CoverageCommandTest extends BaseTestCase
         $this->assertFileExists($coverageFileName);
         $fileContent = file_get_contents($coverageFileName);
         unlink($coverageFileName);
+        $this->assertNotFalse($fileContent);
         $this->assertContains('Coverage Report', $fileContent);
         $this->assertContains('StubbedParaunitProcess', $fileContent);
     }
@@ -70,6 +71,7 @@ class CoverageCommandTest extends BaseTestCase
         $this->assertFileExists($coverageFileName);
         $fileContent = file_get_contents($coverageFileName);
         unlink($coverageFileName);
+        $this->assertNotFalse($fileContent);
         $this->assertContains('Coverage Report', $fileContent);
         $this->assertNotContains('StubbedParaunitProcess', $fileContent);
     }
@@ -109,6 +111,11 @@ class CoverageCommandTest extends BaseTestCase
         return new CommandTester($command);
     }
 
+    /**
+     * @param array<string, string|null> $additionalArguments
+     *
+     * @return string[]
+     */
     private function prepareArguments(array $additionalArguments = []): array
     {
         return array_merge([

--- a/tests/Functional/Command/CoverageCommandTest.php
+++ b/tests/Functional/Command/CoverageCommandTest.php
@@ -114,7 +114,7 @@ class CoverageCommandTest extends BaseTestCase
     /**
      * @param array<string, string|null> $additionalArguments
      *
-     * @return string[]
+     * @return array<string, string|null>
      */
     private function prepareArguments(array $additionalArguments = []): array
     {

--- a/tests/Functional/Parser/JSON/LogParserTest.php
+++ b/tests/Functional/Parser/JSON/LogParserTest.php
@@ -47,6 +47,9 @@ class LogParserTest extends BaseFunctionalTestCase
         }
     }
 
+    /**
+     * @return (string|bool)[][]
+     */
     public function parsableResultsProvider(): array
     {
         return [

--- a/tests/Functional/Runner/RunnerTest.php
+++ b/tests/Functional/Runner/RunnerTest.php
@@ -45,8 +45,8 @@ class RunnerTest extends BaseIntegrationTestCase
 
         $this->assertNotEquals(0, $this->executeRunner());
 
+        /** @var int $retryCount */
         $retryCount = $this->getParameter('paraunit.max_retry_count');
-        $this->assertIsInt($retryCount);
         $this->assertContains(str_repeat('A', $retryCount) . 'E', $output->getOutput());
         $this->assertOutputOrder($output, [
             'Errors output',

--- a/tests/Functional/Runner/RunnerTest.php
+++ b/tests/Functional/Runner/RunnerTest.php
@@ -46,6 +46,7 @@ class RunnerTest extends BaseIntegrationTestCase
         $this->assertNotEquals(0, $this->executeRunner());
 
         $retryCount = $this->getParameter('paraunit.max_retry_count');
+        $this->assertIsInt($retryCount);
         $this->assertContains(str_repeat('A', $retryCount) . 'E', $output->getOutput());
         $this->assertOutputOrder($output, [
             'Errors output',

--- a/tests/Functional/Runner/RunnerWithCoverageTest.php
+++ b/tests/Functional/Runner/RunnerWithCoverageTest.php
@@ -13,15 +13,10 @@ use Tests\BaseIntegrationTestCase;
  */
 class RunnerWithCoverageTest extends BaseIntegrationTestCase
 {
-    public function __construct($name = null, array $data = [], $dataName = '')
-    {
-        parent::__construct($name, $data, $dataName);
-
-        $this->configuration = new CoverageConfiguration(true);
-    }
-
     public function testAllGreen(): void
     {
+        $this->configuration = new CoverageConfiguration(true);
+
         $this->setTextFilter('ThreeGreenTestStub.php');
         $this->loadContainer();
         /** @var Runner $runner */

--- a/tests/Unit/Command/CoverageCommandTest.php
+++ b/tests/Unit/Command/CoverageCommandTest.php
@@ -60,6 +60,9 @@ class CoverageCommandTest extends BaseUnitTestCase
         $this->assertEquals(0, $exitCode);
     }
 
+    /**
+     * @return (string|bool)[][]
+     */
     public function validCoverageOptionsProvider(): array
     {
         return [

--- a/tests/Unit/Configuration/CoverageConfigurationTest.php
+++ b/tests/Unit/Configuration/CoverageConfigurationTest.php
@@ -159,6 +159,7 @@ class CoverageConfigurationTest extends BaseUnitTestCase
         $processors = $property->getValue($coverageResult);
 
         $this->assertCount(1, $processors, 'Wrong count of coverage processors');
+        $this->assertTrue(class_exists($processorClass));
         $this->assertInstanceOf($processorClass, $processors[0]);
     }
 

--- a/tests/Unit/Configuration/CoverageConfigurationTest.php
+++ b/tests/Unit/Configuration/CoverageConfigurationTest.php
@@ -162,6 +162,9 @@ class CoverageConfigurationTest extends BaseUnitTestCase
         $this->assertInstanceOf($processorClass, $processors[0]);
     }
 
+    /**
+     * @return string[][]
+     */
     public function cliOptionsProvider(): array
     {
         return [

--- a/tests/Unit/Configuration/OutputFileTest.php
+++ b/tests/Unit/Configuration/OutputFileTest.php
@@ -30,6 +30,9 @@ class OutputFileTest extends BaseUnitTestCase
         $outputFile->getFilePath();
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function emptyFilesProvider(): array
     {
         return [

--- a/tests/Unit/Coverage/Processor/TextSummaryTest.php
+++ b/tests/Unit/Coverage/Processor/TextSummaryTest.php
@@ -31,6 +31,7 @@ class TextSummaryTest extends BaseUnitTestCase
         $this->assertFileExists($targetFile->getFilePath());
         $content = file_get_contents($targetFile->getFilePath());
         unlink($targetFile->getFilePath());
+        $this->assertNotFalse($content);
         $this->assertContains($expectedString, $content);
     }
 
@@ -48,6 +49,9 @@ class TextSummaryTest extends BaseUnitTestCase
         $text->process($this->createCodeCoverage());
     }
 
+    /**
+     * @return (bool|string)[][]
+     */
     public function colorProvider(): array
     {
         return [

--- a/tests/Unit/Coverage/Processor/TextTest.php
+++ b/tests/Unit/Coverage/Processor/TextTest.php
@@ -31,6 +31,7 @@ class TextTest extends BaseUnitTestCase
         $this->assertFileExists($targetFile->getFilePath());
         $content = file_get_contents($targetFile->getFilePath());
         unlink($targetFile->getFilePath());
+        $this->assertNotFalse($content);
         $this->assertContains($expectedString, $content);
     }
 
@@ -48,6 +49,9 @@ class TextTest extends BaseUnitTestCase
         $text->process($this->createCodeCoverage());
     }
 
+    /**
+     * @return (bool|string)[][]
+     */
     public function colorProvider(): array
     {
         return [

--- a/tests/Unit/Filter/FilterTest.php
+++ b/tests/Unit/Filter/FilterTest.php
@@ -16,10 +16,10 @@ class FilterTest extends BaseUnitTestCase
     /** @var string */
     private $absoluteConfigBaseDir;
 
-    public function __construct($name = null, array $data = [], $dataName = '')
+    protected function setUp(): void
     {
-        parent::__construct($name, $data, $dataName);
-        $this->absoluteConfigBaseDir = \dirname(__DIR__, 2) . '/Stub/StubbedXMLConfigs' . DIRECTORY_SEPARATOR;
+        parent::setUp();
+        $this->absoluteConfigBaseDir = $this->absoluteConfigBaseDir ?? \dirname(__DIR__, 2) . '/Stub/StubbedXMLConfigs' . DIRECTORY_SEPARATOR;
     }
 
     public function testFilterTestFilesGetsOnlyRequestedTestsuite(): void
@@ -224,7 +224,7 @@ class FilterTest extends BaseUnitTestCase
         return Xml::loadFile($filePath);
     }
 
-    private function mockPHPUnitConfig(string $configFile)
+    private function mockPHPUnitConfig(string $configFile): PHPUnitConfig
     {
         $this->assertFileExists($configFile, 'Mock not possible, config file to pass does not exist');
 

--- a/tests/Unit/Parser/JSON/GenericParserTest.php
+++ b/tests/Unit/Parser/JSON/GenericParserTest.php
@@ -49,6 +49,9 @@ class GenericParserTest extends BaseUnitTestCase
         }
     }
 
+    /**
+     * @return (string|null|bool)[][]
+     */
     public function matchesProvider(): array
     {
         return [

--- a/tests/Unit/Parser/JSON/LogPrinterTest.php
+++ b/tests/Unit/Parser/JSON/LogPrinterTest.php
@@ -264,6 +264,9 @@ class LogPrinterTest extends BaseUnitTestCase
         return $parsedOutput;
     }
 
+    /**
+     * @param (string|int)[][] $data
+     */
     private function encodeWithStartTestSuite(array $data = []): string
     {
         $logElements = [$this->getStartTestSuiteLog()];
@@ -279,6 +282,9 @@ class LogPrinterTest extends BaseUnitTestCase
         return $result;
     }
 
+    /**
+     * @return (string|int)[]
+     */
     private function getStartTestSuiteLog(): array
     {
         return [

--- a/tests/Unit/Parser/JSON/TestStartParserTest.php
+++ b/tests/Unit/Parser/JSON/TestStartParserTest.php
@@ -37,6 +37,9 @@ class TestStartParserTest extends BaseUnitTestCase
         }
     }
 
+    /**
+     * @return (string|bool)[][]
+     */
     public function logsProvider(): array
     {
         return [

--- a/tests/Unit/Parser/JSON/UnknownResultParserTest.php
+++ b/tests/Unit/Parser/JSON/UnknownResultParserTest.php
@@ -34,6 +34,9 @@ class UnknownResultParserTest extends BaseUnitTestCase
         $this->assertNotNull($parser->handleLogItem(new StubbedParaunitProcess(), $log));
     }
 
+    /**
+     * @return string[][]
+     */
     public function statusesProvider(): array
     {
         return [

--- a/tests/Unit/Printer/ProcessPrinterTest.php
+++ b/tests/Unit/Printer/ProcessPrinterTest.php
@@ -78,6 +78,9 @@ class ProcessPrinterTest extends BaseUnitTestCase
         $printer->onProcessCompleted(new ProcessParsingCompleted($process));
     }
 
+    /**
+     * @return int[][]
+     */
     public function newLineTimesProvider(): array
     {
         return [

--- a/tests/Unit/Proxy/Coverage/FakeDriverTest.php
+++ b/tests/Unit/Proxy/Coverage/FakeDriverTest.php
@@ -21,6 +21,9 @@ class FakeDriverTest extends TestCase
         $driver->$method();
     }
 
+    /**
+     * @return \Generator<string[]>
+     */
     public function methodNameProvider(): \Generator
     {
         yield ['start'];

--- a/tests/Unit/Runner/PipelineCollectionTest.php
+++ b/tests/Unit/Runner/PipelineCollectionTest.php
@@ -114,6 +114,9 @@ class PipelineCollectionTest extends BaseUnitTestCase
         $this->assertSame($isPipeline1Empty || $isPipeline2Empty, $pipelineCollection->hasEmptySlots());
     }
 
+    /**
+     * @return bool[][]
+     */
     public function pipelineStateProvider(): array
     {
         return [


### PR DESCRIPTION
This update will unlock Symfony 5 compat, due to PHPStan no longer relying on external dependencies.