### PR TITLE
Support pcov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,10 @@ jobs:
     - stage: Code style, static analysis and E2E
       name: End2End with Pcov
       env: XDEBUG=true
-      install: composer install --no-dev --no-interaction
-      script:
+      install: 
         - pecl install pcov
+        - composer update --no-dev --no-interaction
+      script:
         - src/Bin/paraunit run FakeDriverTest
         - src/Bin/paraunit coverage FakeDriverTest --text
     - name: End2End with Xdebug

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,19 @@ jobs:
       php: 7.2
       install: composer install --prefer-dist --no-interaction
     - stage: Code style, static analysis and E2E
-      env: E2E=true
+      name: End2End with Pcov
+      env: XDEBUG=true
+      install: composer install --no-dev --no-interaction
+      script:
+        - pecl install pcov
+        - src/Bin/paraunit run FakeDriverTest
+        - src/Bin/paraunit coverage FakeDriverTest --text
+    - name: End2End with Xdebug
+      env: XDEBUG=true
       install: composer install --no-dev --no-interaction
       script: 
         - src/Bin/paraunit run FakeDriverTest
         - src/Bin/paraunit coverage FakeDriverTest --text
-        - src/Bin/paraunit coverage FakeDriverTest --text-summary
     - env: PHPSTAN=true
       script: composer phpstan
     - env: CS-FIXER=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ First stable release. The following changes are in comparison to the previous, u
 ## [1.0.0-beta2] - TBA
 ### Added
  * Add support for PHP 7.4
+ * Add support for ext-pcov as a coverage driver [#146](https://github.com/facile-it/paraunit/pull/146)
 
 ### Changed
  * Update PHPStan to 0.12 [#145](https://github.com/facile-it/paraunit/pull/145)
+ * Prefer Pcov or Xdebug over PHPDBG as coverage driver [#146](https://github.com/facile-it/paraunit/pull/146)
 
 ## [1.0.0-beta1] - 2019-04-08
 ### Breaking changes

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
         }
     },
     "suggest": {
+        "ext-pcov": "A coverage driver for faster collection",
         "dama/doctrine-test-bundle": "Useful for Symfony+Doctrine functional testing, providing DB isolation"
     }
 }

--- a/src/Configuration/DependencyInjection/CoverageContainerDefinition.php
+++ b/src/Configuration/DependencyInjection/CoverageContainerDefinition.php
@@ -14,6 +14,7 @@ use Paraunit\Coverage\CoverageResult;
 use Paraunit\Printer\CoveragePrinter;
 use Paraunit\Process\CommandLineWithCoverage;
 use Paraunit\Process\ProcessFactoryInterface;
+use Paraunit\Proxy\PcovProxy;
 use Paraunit\Proxy\XDebugProxy;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,6 +38,7 @@ class CoverageContainerDefinition extends ParallelContainerDefinition
     {
         $container->setDefinition(PHPDbgBinFile::class, new Definition(PHPDbgBinFile::class));
         $container->setDefinition(XDebugProxy::class, new Definition(XDebugProxy::class));
+        $container->setDefinition(PcovProxy::class, new Definition(PcovProxy::class));
     }
 
     private function configureProcessWithCoverage(ContainerBuilder $container): void

--- a/src/Configuration/DependencyInjection/CoverageContainerDefinition.php
+++ b/src/Configuration/DependencyInjection/CoverageContainerDefinition.php
@@ -45,9 +45,12 @@ class CoverageContainerDefinition extends ParallelContainerDefinition
     {
         $container->setDefinition(CommandLineWithCoverage::class, new Definition(CommandLineWithCoverage::class, [
             new Reference(PHPUnitBinFile::class),
+            new Reference(PcovProxy::class),
+            new Reference(XDebugProxy::class),
             new Reference(PHPDbgBinFile::class),
             new Reference(TempFilenameFactory::class),
         ]));
+
         $container->getDefinition(ProcessFactoryInterface::class)
             ->setArguments([
                 new Reference(CommandLineWithCoverage::class),

--- a/src/Process/CommandLineWithCoverage.php
+++ b/src/Process/CommandLineWithCoverage.php
@@ -47,11 +47,11 @@ class CommandLineWithCoverage extends CommandLine
      */
     public function getExecutable(): array
     {
-        if ($this->pcovProxy->isInstalled() && ! $this->pcovProxy->isEnabled()) {
+        if ($this->pcovProxy->isLoaded()) {
             return ['php', '-d pcov.enable=1', $this->phpUnitBin->getPhpUnitBin()];
         }
 
-        if ($this->xdebugOrPcovAreAvailable()) {
+        if ($this->xdebugProxy->isLoaded()) {
             return parent::getExecutable();
         }
 
@@ -69,7 +69,7 @@ class CommandLineWithCoverage extends CommandLine
      */
     public function getOptions(PHPUnitConfig $config): array
     {
-        if ($this->xdebugOrPcovAreAvailable()) {
+        if ($this->pcovProxy->isLoaded() || $this->xdebugProxy->isLoaded()) {
             return parent::getOptions($config);
         }
 
@@ -92,10 +92,5 @@ class CommandLineWithCoverage extends CommandLine
         $options[] = '--coverage-php=' . $this->filenameFactory->getFilenameForCoverage(md5($testFilename));
 
         return $options;
-    }
-
-    private function xdebugOrPcovAreAvailable(): bool
-    {
-        return $this->pcovProxy->isLoaded() || $this->xdebugProxy->isLoaded();
     }
 }

--- a/src/Process/CommandLineWithCoverage.php
+++ b/src/Process/CommandLineWithCoverage.php
@@ -48,7 +48,7 @@ class CommandLineWithCoverage extends CommandLine
     public function getExecutable(): array
     {
         if ($this->pcovProxy->isLoaded()) {
-            return ['php', '-d pcov.enable=1', $this->phpUnitBin->getPhpUnitBin()];
+            return ['php', '-d pcov.enabled=1', $this->phpUnitBin->getPhpUnitBin()];
         }
 
         if ($this->xdebugProxy->isLoaded()) {

--- a/src/Process/CommandLineWithCoverage.php
+++ b/src/Process/CommandLineWithCoverage.php
@@ -6,7 +6,6 @@ namespace Paraunit\Process;
 
 use Paraunit\Configuration\PHPDbgBinFile;
 use Paraunit\Configuration\PHPUnitBinFile;
-use Paraunit\Configuration\PHPUnitConfig;
 use Paraunit\Configuration\TempFilenameFactory;
 use Paraunit\Proxy\PcovProxy;
 use Paraunit\Proxy\XDebugProxy;
@@ -56,31 +55,11 @@ class CommandLineWithCoverage extends CommandLine
         }
 
         if ($this->phpDbgBinFile->isAvailable()) {
-            return [$this->phpDbgBinFile->getPhpDbgBin()];
-        }
-
-        throw new \RuntimeException('No coverage driver seems to be available; possible choices are Pcov, xdebug or PHPDBG');
-    }
-
-    /**
-     * @throws \RuntimeException
-     *
-     * @return string[]
-     */
-    public function getOptions(PHPUnitConfig $config): array
-    {
-        if ($this->pcovProxy->isLoaded() || $this->xdebugProxy->isLoaded()) {
-            return parent::getOptions($config);
-        }
-
-        if ($this->phpDbgBinFile->isAvailable()) {
-            return array_merge(
-                [
-                    '-qrr',
-                    $this->phpUnitBin->getPhpUnitBin(),
-                ],
-                parent::getOptions($config)
-            );
+            return [
+                $this->phpDbgBinFile->getPhpDbgBin(),
+                '-qrr',
+                $this->phpUnitBin->getPhpUnitBin(),
+            ];
         }
 
         throw new \RuntimeException('No coverage driver seems to be available; possible choices are Pcov, xdebug or PHPDBG');

--- a/src/Process/CommandLineWithCoverage.php
+++ b/src/Process/CommandLineWithCoverage.php
@@ -47,6 +47,10 @@ class CommandLineWithCoverage extends CommandLine
      */
     public function getExecutable(): array
     {
+        if ($this->pcovProxy->isInstalled() && ! $this->pcovProxy->isEnabled()) {
+            return ['php', '-d pcov.enable=1', $this->phpUnitBin->getPhpUnitBin()];
+        }
+
         if ($this->xdebugOrPcovAreAvailable()) {
             return parent::getExecutable();
         }

--- a/src/Proxy/PcovProxy.php
+++ b/src/Proxy/PcovProxy.php
@@ -8,16 +8,6 @@ class PcovProxy
 {
     public function isLoaded(): bool
     {
-        return $this->isInstalled() && $this->isEnabled();
-    }
-
-    public function isInstalled(): bool
-    {
         return extension_loaded('pcov');
-    }
-
-    public function isEnabled(): bool
-    {
-        return (bool)ini_get('pcov.enabled');
     }
 }

--- a/src/Proxy/PcovProxy.php
+++ b/src/Proxy/PcovProxy.php
@@ -1,21 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Paraunit\Proxy;
 
 class PcovProxy
 {
-    public function isReady(): bool 
-    {
-        return $this->isLoaded() && $this->isEnabled();
-    }
-
     public function isLoaded(): bool
     {
-        return extension_loaded('pcov');
-    }
-
-    public function isEnabled(): bool
-    {
-        return ini_get('pcov.enabled');
+        return extension_loaded('pcov') && ini_get('pcov.enabled');
     }
 }

--- a/src/Proxy/PcovProxy.php
+++ b/src/Proxy/PcovProxy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Paraunit\Proxy;
+
+class PcovProxy
+{
+    public function isReady(): bool 
+    {
+        return $this->isLoaded() && $this->isEnabled();
+    }
+
+    public function isLoaded(): bool
+    {
+        return extension_loaded('pcov');
+    }
+
+    public function isEnabled(): bool
+    {
+        return ini_get('pcov.enabled');
+    }
+}

--- a/src/Proxy/PcovProxy.php
+++ b/src/Proxy/PcovProxy.php
@@ -8,6 +8,16 @@ class PcovProxy
 {
     public function isLoaded(): bool
     {
-        return extension_loaded('pcov') && ini_get('pcov.enabled');
+        return $this->isInstalled() && $this->isEnabled();
+    }
+
+    public function isInstalled(): bool
+    {
+        return extension_loaded('pcov');
+    }
+
+    public function isEnabled(): bool
+    {
+        return (bool)ini_get('pcov.enabled');
     }
 }

--- a/tests/Unit/Process/CommandLineWithCoverageTest.php
+++ b/tests/Unit/Process/CommandLineWithCoverageTest.php
@@ -188,8 +188,8 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
      */
     public function extensionProxiesProvider(): \Generator
     {
-        yield [$this->mockPcov(true), $this->mockXdebug(true), ['php', '-d pcov.enable=1', 'path/to/phpunit']];
-        yield [$this->mockPcov(true), $this->mockXdebug(false), ['php', '-d pcov.enable=1', 'path/to/phpunit']];
+        yield [$this->mockPcov(true), $this->mockXdebug(true), ['php', '-d pcov.enabled=1', 'path/to/phpunit']];
+        yield [$this->mockPcov(true), $this->mockXdebug(false), ['php', '-d pcov.enabled=1', 'path/to/phpunit']];
         yield [$this->mockPcov(false), $this->mockXdebug(true), ['php', 'path/to/phpunit']];
     }
 

--- a/tests/Unit/Process/CommandLineWithCoverageTest.php
+++ b/tests/Unit/Process/CommandLineWithCoverageTest.php
@@ -20,8 +20,9 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
 {
     /**
      * @dataProvider extensionProxiesProvider
+     * @param string[] $expected
      */
-    public function testGetExecutableWithDriverByExtension(PcovProxy $pcovProxy, XDebugProxy $xdebugProxy): void
+    public function testGetExecutableWithDriverByExtension(PcovProxy $pcovProxy, XDebugProxy $xdebugProxy, array $expected): void
     {
         $phpunit = $this->prophesize(PHPUnitBinFile::class);
         $phpunit->getPhpUnitBin()
@@ -37,7 +38,7 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
             $tempFileNameFactory->reveal()
         );
 
-        $this->assertEquals(['php', 'path/to/phpunit'], $cli->getExecutable());
+        $this->assertEquals($expected, $cli->getExecutable());
     }
 
     public function testGetExecutableWithDbg(): void
@@ -183,13 +184,13 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
     }
 
     /**
-     * @return \Generator<(PcovProxy|XDebugProxy)[]>
+     * @return \Generator<array{PcovProxy, XDebugProxy, string[]}>
      */
     public function extensionProxiesProvider(): \Generator
     {
-        yield [$this->mockPcov(true), $this->mockXdebug(true)];
-        yield [$this->mockPcov(true), $this->mockXdebug(false)];
-        yield [$this->mockPcov(false), $this->mockXdebug(true)];
+        yield [$this->mockPcov(true), $this->mockXdebug(true), ['php', '-d pcov.enable=1', 'path/to/phpunit']];
+        yield [$this->mockPcov(true), $this->mockXdebug(false), ['php', '-d pcov.enable=1', 'path/to/phpunit']];
+        yield [$this->mockPcov(false), $this->mockXdebug(true), ['php', 'path/to/phpunit']];
     }
 
     private function mockPcov(bool $enabled): PcovProxy


### PR DESCRIPTION
This will add Pcov as an available driver for collecting code coverage: https://github.com/krakjoe/pcov

Since Pcov and the latest versions of Xdebug are faster, this also changes the order of preferences, and puts PHPDBG as a mere fallback if both the extensions are unavailable.