### PR TITLE
Fix behavior of CoveragePrinter

### DIFF
--- a/src/Configuration/DependencyInjection/CoverageContainerDefinition.php
+++ b/src/Configuration/DependencyInjection/CoverageContainerDefinition.php
@@ -74,6 +74,7 @@ class CoverageContainerDefinition extends ParallelContainerDefinition
         $container->setDefinition(CoveragePrinter::class, new Definition(CoveragePrinter::class, [
             new Reference(PHPDbgBinFile::class),
             new Reference(XDebugProxy::class),
+            new Reference(PcovProxy::class),
             new Reference(OutputInterface::class),
         ]));
     }

--- a/tests/Unit/Printer/CoveragePrinterTest.php
+++ b/tests/Unit/Printer/CoveragePrinterTest.php
@@ -24,7 +24,7 @@ class CoveragePrinterTest extends BaseUnitTestCase
 
         $printer->onEngineBeforeStart();
 
-        $this->assertSame('Coverage driver in use: ' . $expected . PHP_EOL, $output->getOutput());
+        $this->assertSame('Coverage driver in use: ' . $expected, trim($output->getOutput()));
     }
 
     /**

--- a/tests/Unit/Printer/CoveragePrinterTest.php
+++ b/tests/Unit/Printer/CoveragePrinterTest.php
@@ -6,45 +6,40 @@ namespace Tests\Unit\Printer;
 
 use Paraunit\Configuration\PHPDbgBinFile;
 use Paraunit\Printer\CoveragePrinter;
+use Paraunit\Proxy\PcovProxy;
 use Paraunit\Proxy\XDebugProxy;
 use Tests\BaseUnitTestCase;
 use Tests\Stub\UnformattedOutputStub;
 
 class CoveragePrinterTest extends BaseUnitTestCase
 {
-    public function testOnEngineBeforeStartWithPHPDBGEngine(): void
+    /**
+     * @dataProvider coverageDriverProvider
+     */
+    public function testOnEngineBeforeStart(PHPDbgBinFile $phpdbg, XDebugProxy $xdebug, PcovProxy $pcov, string $expected): void
     {
         $output = new UnformattedOutputStub();
 
-        $printer = new CoveragePrinter($this->mockPhpdbgBin(true), $this->mockXdebugLoaded(false), $output);
+        $printer = new CoveragePrinter($phpdbg, $xdebug, $pcov, $output);
 
         $printer->onEngineBeforeStart();
 
-        $this->assertContains('Coverage driver in use: PHPDBG', $output->getOutput());
+        $this->assertSame('Coverage driver in use: ' . $expected . PHP_EOL, $output->getOutput());
     }
 
-    public function testOnEngineBeforeStartWithxDebugEngine(): void
+    /**
+     * @return \Generator<array{PHPDbgBinFile, XDebugProxy, PcovProxy, string}>
+     */
+    public function coverageDriverProvider(): \Generator
     {
-        $output = new UnformattedOutputStub();
-
-        $printer = new CoveragePrinter($this->mockPhpdbgBin(false), $this->mockXdebugLoaded(true), $output);
-
-        $printer->onEngineBeforeStart();
-
-        $this->assertContains('Coverage driver in use: xDebug', $output->getOutput());
-    }
-
-    public function testOnEngineBeforeStartWithWarningForBothEnginesEnabled(): void
-    {
-        $output = new UnformattedOutputStub();
-
-        $printer = new CoveragePrinter($this->mockPhpdbgBin(true), $this->mockXdebugLoaded(true), $output);
-
-        $printer->onEngineBeforeStart();
-
-        $this->assertContains('WARNING', $output->getOutput());
-        $this->assertContains('both driver', $output->getOutput());
-        $this->assertNotContains('xDebug', $output->getOutput());
+        yield [$this->mockPhpdbgBin(true), $this->mockXdebugLoaded(true), $this->mockPcovLoaded(true), 'Pcov'];
+        yield [$this->mockPhpdbgBin(true), $this->mockXdebugLoaded(false), $this->mockPcovLoaded(true), 'Pcov'];
+        yield [$this->mockPhpdbgBin(false), $this->mockXdebugLoaded(true), $this->mockPcovLoaded(true), 'Pcov'];
+        yield [$this->mockPhpdbgBin(false), $this->mockXdebugLoaded(false), $this->mockPcovLoaded(true), 'Pcov'];
+        yield [$this->mockPhpdbgBin(true), $this->mockXdebugLoaded(true), $this->mockPcovLoaded(false), 'Xdebug'];
+        yield [$this->mockPhpdbgBin(false), $this->mockXdebugLoaded(true), $this->mockPcovLoaded(false), 'Xdebug'];
+        yield [$this->mockPhpdbgBin(true), $this->mockXdebugLoaded(false), $this->mockPcovLoaded(false), 'PHPDBG'];
+        yield [$this->mockPhpdbgBin(false), $this->mockXdebugLoaded(false), $this->mockPcovLoaded(false), 'NO COVERAGE DRIVER FOUND!'];
     }
 
     private function mockPhpdbgBin(bool $shouldReturn): PHPDbgBinFile
@@ -59,6 +54,15 @@ class CoveragePrinterTest extends BaseUnitTestCase
     private function mockXdebugLoaded(bool $shouldReturn): XDebugProxy
     {
         $xdebug = $this->prophesize(XDebugProxy::class);
+        $xdebug->isLoaded()
+            ->willReturn($shouldReturn);
+
+        return $xdebug->reveal();
+    }
+
+    private function mockPcovLoaded(bool $shouldReturn): PcovProxy
+    {
+        $xdebug = $this->prophesize(PcovProxy::class);
         $xdebug->isLoaded()
             ->willReturn($shouldReturn);
 


### PR DESCRIPTION
This is a followup of #146, where I forgot to update the printed info at the top of the execution. This highlight the advantages of Pcov and of the changed drivers' priority.