### PR TITLE
Add Rector

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,7 @@ jobs:
       - uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
-      - run: bin/phpunit --coverage-clover=coverage.xml
+      - run: vendor/bin/phpunit --coverage-clover=coverage.xml
       - uses: codecov/codecov-action@v1
         with:
           file: './coverage.xml'
@@ -65,7 +65,7 @@ jobs:
         with:
           php-version: '8.1'
       - uses: ramsey/composer-install@v2
-      - run: bin/php-cs-fixer fix --ansi --verbose --dry-run
+      - run: vendor/bin/php-cs-fixer fix --ansi --verbose --dry-run
   PHPStan:
     runs-on: ubuntu-latest
     name: PHPStan
@@ -75,7 +75,7 @@ jobs:
         with:
           php-version: '8.1'
       - uses: ramsey/composer-install@v2
-      - run: bin/phpstan analyse
+      - run: vendor/bin/phpstan analyse
   Psalm:
     runs-on: ubuntu-latest
     name: Psalm
@@ -85,7 +85,7 @@ jobs:
         with:
           php-version: '8.1'
       - uses: ramsey/composer-install@v2
-      - run: bin/psalm
+      - run: vendor/bin/psalm
   End2End:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,6 +56,16 @@ jobs:
         with:
           file: './coverage.xml'
           fail_ci_if_error: true
+  Rector:
+    runs-on: ubuntu-latest
+    name: Code style
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+      - uses: ramsey/composer-install@v2
+      - run: vendor/bin/rector --ansi --dry-run
   PHP-CS-Fixer:
     runs-on: ubuntu-latest
     name: Code style

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,16 @@ composer-install: start
 pre-commit-check: rector cs-fix psalm phpstan tests
 
 rector: start
-	docker-compose exec php bin/php-cs-fixer fix --verbose --ansi
+	docker-compose exec php vendor/bin/php-cs-fixer fix --verbose --ansi
 
 cs-fix: start
-	docker-compose exec php bin/php-cs-fixer fix --verbose --ansi
+	docker-compose exec php vendor/bin/php-cs-fixer fix --verbose --ansi
 
 psalm: start
-	docker-compose exec php bin/psalm
+	docker-compose exec php vendor/bin/psalm
 
 phpstan: start
-	docker-compose exec php bin/phpstan analyse --ansi --memory-limit=-1
+	docker-compose exec php vendor/bin/phpstan analyse --ansi --memory-limit=-1
 
 tests: start
-	docker-compose exec php bin/phpunit --colors=always
+	docker-compose exec php vendor/bin/phpunit --colors=always

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ composer-install: start
 pre-commit-check: rector cs-fix psalm phpstan tests
 
 rector: start
-	docker-compose exec php vendor/bin/php-cs-fixer fix --verbose --ansi
+	docker-compose exec php vendor/bin/rector --ansi
 
 cs-fix: start
 	docker-compose exec php vendor/bin/php-cs-fixer fix --verbose --ansi

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ start:
 composer-install: start
 	docker-compose exec php composer install
 
-pre-commit-check: cs-fix psalm phpstan tests
+pre-commit-check: rector cs-fix psalm phpstan tests
+
+rector: start
+	docker-compose exec php bin/php-cs-fixer fix --verbose --ansi
 
 cs-fix: start
 	docker-compose exec php bin/php-cs-fixer fix --verbose --ansi

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,6 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "bin-dir": "bin",
         "allow-plugins": {
             "facile-it/facile-coding-standard": true,
             "phpstan/extension-installer": true
@@ -91,11 +90,6 @@
         "psr-4": {
             "Tests\\": "tests"
         }
-    },
-    "scripts": {
-        "phpstan": "phpstan analyse",
-        "cs-check": "php -n bin/php-cs-fixer fix --dry-run --diff",
-        "cs-fix": "php -n bin/php-cs-fixer fix"
     },
     "minimum-stability": "dev",
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "phpunit/php-invoker": "^4.0",
         "psalm/plugin-phpunit": "^0.16.1",
         "psalm/plugin-symfony": "^3.1",
+        "rector/rector": "^0.15",
         "symfony/expression-language": "^4.4||^5.0||^6.0",
         "symfony/phpunit-bridge": "^6.1",
         "vimeo/psalm": "dev-allow-diff-5 as 4.23.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "791df6e0a981592a87290a78d5346e72",
+    "content-hash": "1286739f5fa8b6cc6bbd08b260cfa8bc",
     "packages": [
         {
             "name": "jean85/pretty-package-versions",
@@ -4801,6 +4801,62 @@
             "time": "2021-07-14T16:46:02+00:00"
         },
         {
+            "name": "rector/rector",
+            "version": "0.15.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "a43370e1f4c47aaa96c0f85bf9db73db1be7552f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/a43370e1f4c47aaa96c0f85bf9db73db1be7552f",
+                "reference": "a43370e1f4c47aaa96c0f85bf9db73db1be7552f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.9.7"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-php-parser": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.14-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.15.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-01-13T21:14:19+00:00"
+        },
+        {
             "name": "symfony/cache",
             "version": "v6.2.4",
             "source": {
@@ -6410,7 +6466,7 @@
         "phpspec/prophecy-phpunit": 20,
         "vimeo/psalm": 20
     },
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -297,12 +297,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "169d280501d0088ef107fe1834a2a3b704a475e9"
+                "reference": "48539b2417c151a3e566cde9d5cbe80048845b15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/169d280501d0088ef107fe1834a2a3b704a475e9",
-                "reference": "169d280501d0088ef107fe1834a2a3b704a475e9",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48539b2417c151a3e566cde9d5cbe80048845b15",
+                "reference": "48539b2417c151a3e566cde9d5cbe80048845b15",
                 "shasum": ""
             },
             "require": {
@@ -367,7 +367,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:37:56+00:00"
+            "time": "2023-01-15T14:06:23+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -375,12 +375,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "4492e671b2a1fe57a916271a7034872a56c91ee9"
+                "reference": "36e6caf11d286e15090612c2d9cb1be40c42ff80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4492e671b2a1fe57a916271a7034872a56c91ee9",
-                "reference": "4492e671b2a1fe57a916271a7034872a56c91ee9",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/36e6caf11d286e15090612c2d9cb1be40c42ff80",
+                "reference": "36e6caf11d286e15090612c2d9cb1be40c42ff80",
                 "shasum": ""
             },
             "require": {
@@ -428,7 +428,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:44:40+00:00"
+            "time": "2023-01-15T14:07:03+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -436,12 +436,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "ddc3cc68989a1b6de9967b04bccd2d2f2d8bc59e"
+                "reference": "e130dd8b66103ebb3b7de52cea01c8a84ab4058b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/ddc3cc68989a1b6de9967b04bccd2d2f2d8bc59e",
-                "reference": "ddc3cc68989a1b6de9967b04bccd2d2f2d8bc59e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/e130dd8b66103ebb3b7de52cea01c8a84ab4058b",
+                "reference": "e130dd8b66103ebb3b7de52cea01c8a84ab4058b",
                 "shasum": ""
             },
             "require": {
@@ -492,7 +492,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:44:50+00:00"
+            "time": "2023-01-15T14:07:11+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -500,12 +500,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "4895ebfcafcbd97c0a009a3da8ab54cafab34dd1"
+                "reference": "59ab4d8aca8e63f306e75eb730acf746a49ce382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/4895ebfcafcbd97c0a009a3da8ab54cafab34dd1",
-                "reference": "4895ebfcafcbd97c0a009a3da8ab54cafab34dd1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/59ab4d8aca8e63f306e75eb730acf746a49ce382",
+                "reference": "59ab4d8aca8e63f306e75eb730acf746a49ce382",
                 "shasum": ""
             },
             "require": {
@@ -552,7 +552,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:45:47+00:00"
+            "time": "2023-01-15T14:07:37+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -560,12 +560,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "94c01c6b18ff2e792ce9c489252f6240d1b25525"
+                "reference": "5f788db8dc5da5a6a145112e5bd77e9ba8eb44a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/94c01c6b18ff2e792ce9c489252f6240d1b25525",
-                "reference": "94c01c6b18ff2e792ce9c489252f6240d1b25525",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5f788db8dc5da5a6a145112e5bd77e9ba8eb44a0",
+                "reference": "5f788db8dc5da5a6a145112e5bd77e9ba8eb44a0",
                 "shasum": ""
             },
             "require": {
@@ -612,7 +612,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:45:57+00:00"
+            "time": "2023-01-15T14:07:20+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -620,12 +620,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "01b41781ada83e0719bbf350b43295ed90bd3ad9"
+                "reference": "6333dfcaa698a020e8a7c437857dbdc4203fbc63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/01b41781ada83e0719bbf350b43295ed90bd3ad9",
-                "reference": "01b41781ada83e0719bbf350b43295ed90bd3ad9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6333dfcaa698a020e8a7c437857dbdc4203fbc63",
+                "reference": "6333dfcaa698a020e8a7c437857dbdc4203fbc63",
                 "shasum": ""
             },
             "require": {
@@ -713,7 +713,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T09:11:17+00:00"
+            "time": "2023-01-15T13:41:38+00:00"
         },
         {
             "name": "psr/container",
@@ -824,12 +824,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "516b68848d8835a4f4c9faa7d2f1e96727c403d0"
+                "reference": "0c47414baf4c42b32e138d1025b4e00ca3771c75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/516b68848d8835a4f4c9faa7d2f1e96727c403d0",
-                "reference": "516b68848d8835a4f4c9faa7d2f1e96727c403d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/0c47414baf4c42b32e138d1025b4e00ca3771c75",
+                "reference": "0c47414baf4c42b32e138d1025b4e00ca3771c75",
                 "shasum": ""
             },
             "require": {
@@ -873,7 +873,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:40:18+00:00"
+            "time": "2023-01-15T14:08:09+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -881,12 +881,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "4482bd256f2c455642cf5949acda6e5be5c4733e"
+                "reference": "811c53997f753d54cf14db715312e7fe7595fbac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/4482bd256f2c455642cf5949acda6e5be5c4733e",
-                "reference": "4482bd256f2c455642cf5949acda6e5be5c4733e",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/811c53997f753d54cf14db715312e7fe7595fbac",
+                "reference": "811c53997f753d54cf14db715312e7fe7595fbac",
                 "shasum": ""
             },
             "require": {
@@ -930,7 +930,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:40:38+00:00"
+            "time": "2023-01-15T14:05:48+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -938,12 +938,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ba7e5e826a43c43c0e9b2913c838911581782a56"
+                "reference": "48bf16e14a8395909fb7fdbdbb3963ba2cbef1ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ba7e5e826a43c43c0e9b2913c838911581782a56",
-                "reference": "ba7e5e826a43c43c0e9b2913c838911581782a56",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/48bf16e14a8395909fb7fdbdbb3963ba2cbef1ee",
+                "reference": "48bf16e14a8395909fb7fdbdbb3963ba2cbef1ee",
                 "shasum": ""
             },
             "require": {
@@ -986,7 +986,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:41:00+00:00"
+            "time": "2023-01-15T14:05:58+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -994,12 +994,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ef3a88a13a48f3db94e1c7af4ba090819d3aa6cd"
+                "reference": "f39fc413fa1b16152ab642821c70a2c7aea8c510"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ef3a88a13a48f3db94e1c7af4ba090819d3aa6cd",
-                "reference": "ef3a88a13a48f3db94e1c7af4ba090819d3aa6cd",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/f39fc413fa1b16152ab642821c70a2c7aea8c510",
+                "reference": "f39fc413fa1b16152ab642821c70a2c7aea8c510",
                 "shasum": ""
             },
             "require": {
@@ -1063,7 +1063,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:41:16+00:00"
+            "time": "2023-01-15T14:06:06+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1071,12 +1071,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "08d8b20a6f503f4db6581269eff06e2997d7d0f4"
+                "reference": "c662903ca023cc0a95efd34026d56437efbc7807"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/08d8b20a6f503f4db6581269eff06e2997d7d0f4",
-                "reference": "08d8b20a6f503f4db6581269eff06e2997d7d0f4",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/c662903ca023cc0a95efd34026d56437efbc7807",
+                "reference": "c662903ca023cc0a95efd34026d56437efbc7807",
                 "shasum": ""
             },
             "require": {
@@ -1121,7 +1121,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:41:27+00:00"
+            "time": "2023-01-15T14:07:46+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1129,12 +1129,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "c9efa614f799376099d2da8b78b7e2afb12b6194"
+                "reference": "4eed0693716b9d6995ddf9dc3152f99e38269912"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c9efa614f799376099d2da8b78b7e2afb12b6194",
-                "reference": "c9efa614f799376099d2da8b78b7e2afb12b6194",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/4eed0693716b9d6995ddf9dc3152f99e38269912",
+                "reference": "4eed0693716b9d6995ddf9dc3152f99e38269912",
                 "shasum": ""
             },
             "require": {
@@ -1188,7 +1188,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:42:08+00:00"
+            "time": "2023-01-15T14:06:14+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1196,12 +1196,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "35f258424c168f4781b20d5bdbd59df44cdfecf8"
+                "reference": "1b3a370780116eeaf03c5680aa8bc774b7ea63e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/35f258424c168f4781b20d5bdbd59df44cdfecf8",
-                "reference": "35f258424c168f4781b20d5bdbd59df44cdfecf8",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b3a370780116eeaf03c5680aa8bc774b7ea63e6",
+                "reference": "1b3a370780116eeaf03c5680aa8bc774b7ea63e6",
                 "shasum": ""
             },
             "require": {
@@ -1252,7 +1252,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:42:19+00:00"
+            "time": "2023-01-15T14:06:22+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1260,12 +1260,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "008a3fe185fc9f61ed6bcd50d65c06f1f10a6c1f"
+                "reference": "789902692697c4f052d1c5021627411bcf3d73a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/008a3fe185fc9f61ed6bcd50d65c06f1f10a6c1f",
-                "reference": "008a3fe185fc9f61ed6bcd50d65c06f1f10a6c1f",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/789902692697c4f052d1c5021627411bcf3d73a0",
+                "reference": "789902692697c4f052d1c5021627411bcf3d73a0",
                 "shasum": ""
             },
             "require": {
@@ -1330,7 +1330,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:42:38+00:00"
+            "time": "2023-01-15T14:06:30+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1338,12 +1338,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "1511a5266cabb6073693bfef176e5fc502c3453c"
+                "reference": "23f9901576850883a345919bcce2de8457e8c0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/1511a5266cabb6073693bfef176e5fc502c3453c",
-                "reference": "1511a5266cabb6073693bfef176e5fc502c3453c",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23f9901576850883a345919bcce2de8457e8c0c4",
+                "reference": "23f9901576850883a345919bcce2de8457e8c0c4",
                 "shasum": ""
             },
             "require": {
@@ -1392,7 +1392,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:42:48+00:00"
+            "time": "2023-01-15T14:06:38+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1400,12 +1400,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e65319f9cb500f735e5562cf34f52c4f4468e7f1"
+                "reference": "b83861ea19220fa61655b4169c79dc14fd798197"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e65319f9cb500f735e5562cf34f52c4f4468e7f1",
-                "reference": "e65319f9cb500f735e5562cf34f52c4f4468e7f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/b83861ea19220fa61655b4169c79dc14fd798197",
+                "reference": "b83861ea19220fa61655b4169c79dc14fd798197",
                 "shasum": ""
             },
             "require": {
@@ -1450,7 +1450,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:42:58+00:00"
+            "time": "2023-01-15T14:07:58+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1458,12 +1458,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "9d5eca8e7e985b043b81a753f0f39168b38c0b50"
+                "reference": "c7e4f59e3062e68b3d4c355998e398b75ef0c372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/9d5eca8e7e985b043b81a753f0f39168b38c0b50",
-                "reference": "9d5eca8e7e985b043b81a753f0f39168b38c0b50",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/c7e4f59e3062e68b3d4c355998e398b75ef0c372",
+                "reference": "c7e4f59e3062e68b3d4c355998e398b75ef0c372",
                 "shasum": ""
             },
             "require": {
@@ -1508,7 +1508,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T09:16:19+00:00"
+            "time": "2023-01-15T14:06:46+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -1516,12 +1516,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "ad28e3e0b352dcfb6cdd55a990a2faded3ebe418"
+                "reference": "250301e9154e19cf97ae90171acd732a1344e462"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/ad28e3e0b352dcfb6cdd55a990a2faded3ebe418",
-                "reference": "ad28e3e0b352dcfb6cdd55a990a2faded3ebe418",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/250301e9154e19cf97ae90171acd732a1344e462",
+                "reference": "250301e9154e19cf97ae90171acd732a1344e462",
                 "shasum": ""
             },
             "require": {
@@ -1564,7 +1564,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:43:42+00:00"
+            "time": "2023-01-15T14:06:54+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1572,12 +1572,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "f49f3851e53f92863d65c9918e195fe49d5fed40"
+                "reference": "a6cf392ac989cebf2de91ffe69c40bf568c228e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f49f3851e53f92863d65c9918e195fe49d5fed40",
-                "reference": "f49f3851e53f92863d65c9918e195fe49d5fed40",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/a6cf392ac989cebf2de91ffe69c40bf568c228e3",
+                "reference": "a6cf392ac989cebf2de91ffe69c40bf568c228e3",
                 "shasum": ""
             },
             "require": {
@@ -1628,7 +1628,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:46:24+00:00"
+            "time": "2023-01-15T14:07:29+00:00"
         },
         {
             "name": "sebastian/type",
@@ -1636,12 +1636,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "c2ca70e86c2bdc8c02d504af9a83f751412837ad"
+                "reference": "a3ef2b58b9b5c5d290ee6ab20785c5309dd791e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/c2ca70e86c2bdc8c02d504af9a83f751412837ad",
-                "reference": "c2ca70e86c2bdc8c02d504af9a83f751412837ad",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/a3ef2b58b9b5c5d290ee6ab20785c5309dd791e8",
+                "reference": "a3ef2b58b9b5c5d290ee6ab20785c5309dd791e8",
                 "shasum": ""
             },
             "require": {
@@ -1685,7 +1685,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:46:37+00:00"
+            "time": "2023-01-15T13:50:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1693,12 +1693,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c2401fef543c43552f5c22361b299862050d8876"
+                "reference": "e13ba4ec095a1653f3ef304ff080fc8028116797"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c2401fef543c43552f5c22361b299862050d8876",
-                "reference": "c2401fef543c43552f5c22361b299862050d8876",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/e13ba4ec095a1653f3ef304ff080fc8028116797",
+                "reference": "e13ba4ec095a1653f3ef304ff080fc8028116797",
                 "shasum": ""
             },
             "require": {
@@ -1739,7 +1739,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T08:46:45+00:00"
+            "time": "2023-01-15T09:28:19+00:00"
         },
         {
             "name": "symfony/console",
@@ -4301,12 +4301,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Jean85/prophecy.git",
-                "reference": "71ea1bcdf20ffdd5e0c0ec20d53665b9dc02a789"
+                "reference": "8759ac27c8b5e84e36e9668822cb245a59023c95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Jean85/prophecy/zipball/71ea1bcdf20ffdd5e0c0ec20d53665b9dc02a789",
-                "reference": "71ea1bcdf20ffdd5e0c0ec20d53665b9dc02a789",
+                "url": "https://api.github.com/repos/Jean85/prophecy/zipball/8759ac27c8b5e84e36e9668822cb245a59023c95",
+                "reference": "8759ac27c8b5e84e36e9668822cb245a59023c95",
                 "shasum": ""
             },
             "require": {
@@ -4363,7 +4363,7 @@
             "support": {
                 "source": "https://github.com/Jean85/prophecy/tree/allow-sebastian-comparator-5"
             },
-            "time": "2023-01-11T21:56:48+00:00"
+            "time": "2023-01-12T11:44:24+00:00"
         },
         {
             "name": "phpspec/prophecy-phpunit",
@@ -4467,16 +4467,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.9",
+            "version": "1.9.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f68d7cc3d0638a01bc6321cb826e4cae7fa6884d"
+                "reference": "60f3d68481eef216199eae7a2603cd5fe124d464"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f68d7cc3d0638a01bc6321cb826e4cae7fa6884d",
-                "reference": "f68d7cc3d0638a01bc6321cb826e4cae7fa6884d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/60f3d68481eef216199eae7a2603cd5fe124d464",
+                "reference": "60f3d68481eef216199eae7a2603cd5fe124d464",
                 "shasum": ""
             },
             "require": {
@@ -4506,7 +4506,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.9"
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.11"
             },
             "funding": [
                 {
@@ -4522,7 +4522,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T14:39:22+00:00"
+            "time": "2023-01-12T14:04:13+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -6466,7 +6466,7 @@
         "phpspec/prophecy-phpunit": 20,
         "vimeo/psalm": 20
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1",

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->importNames();
@@ -21,6 +23,14 @@ return static function (RectorConfig $rectorConfig): void {
 
     // define sets of rules
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_81
+        LevelSetList::UP_TO_PHP_81,
+        SetList::DEAD_CODE,
+        SetList::PSR_4,
+        SetList::TYPE_DECLARATION,
+    ]);
+
+    // skip rules
+    $rectorConfig->skip([
+        ReturnNeverTypeRector::class,
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,8 @@ use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames();
+    $rectorConfig->importShortClasses(false);
     $rectorConfig->parallel();
     $rectorConfig->paths([
         __FILE__,

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return static function (RectorConfig $rectorConfig): void {
     // define sets of rules
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_81,
+        SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
         SetList::PSR_4,
         SetList::TYPE_DECLARATION,

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->parallel();
+    $rectorConfig->paths([
+        __FILE__,
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    // register a single rule
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+
+    // define sets of rules
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_81
+    ]);
+};

--- a/src/Bin/run-paraunit.inc.php
+++ b/src/Bin/run-paraunit.inc.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-use Paraunit\Bin\Paraunit;
+namespace Paraunit\Bin;
 
 if (! ini_get('date.timezone') && ! date_default_timezone_get()) {
     date_default_timezone_set('UTC');
 }
-
 // HOTFIX -- needed to fool the Symfony's WebTestCase
 $_SERVER['argv'][0] = 'phpunit';
-
 $application = Paraunit::createApplication();
 $application->run();

--- a/src/Bin/run-paraunit.inc.php
+++ b/src/Bin/run-paraunit.inc.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Paraunit\Bin\Paraunit;
+
 if (! ini_get('date.timezone') && ! date_default_timezone_get()) {
     date_default_timezone_set('UTC');
 }
@@ -9,5 +11,5 @@ if (! ini_get('date.timezone') && ! date_default_timezone_get()) {
 // HOTFIX -- needed to fool the Symfony's WebTestCase
 $_SERVER['argv'][0] = 'phpunit';
 
-$application = \Paraunit\Bin\Paraunit::createApplication();
+$application = Paraunit::createApplication();
 $application->run();

--- a/src/Command/CoverageCommand.php
+++ b/src/Command/CoverageCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CoverageCommand extends ParallelCommand
 {
     /** @var string[] */
-    private $coverageMethods;
+    private readonly array $coverageMethods;
 
     public function __construct(CoverageConfiguration $configuration)
     {

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -20,7 +20,7 @@ class ParallelCommand extends Command
     protected $configuration;
 
     /** @var PHPUnitOption[] */
-    private $phpunitOptions;
+    private readonly array $phpunitOptions;
 
     public function __construct(ParallelConfiguration $configuration)
     {

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -16,13 +16,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ParallelCommand extends Command
 {
-    /** @var ParallelConfiguration */
-    protected $configuration;
-
     /** @var PHPUnitOption[] */
     private readonly array $phpunitOptions;
 
-    public function __construct(ParallelConfiguration $configuration)
+    public function __construct(protected ParallelConfiguration $configuration)
     {
         $this->phpunitOptions = [
             new PHPUnitOption('whitelist'),
@@ -66,7 +63,6 @@ class ParallelCommand extends Command
         ];
 
         parent::__construct();
-        $this->configuration = $configuration;
     }
 
     protected function configure(): void

--- a/src/Configuration/ChunkSize.php
+++ b/src/Configuration/ChunkSize.php
@@ -7,7 +7,7 @@ namespace Paraunit\Configuration;
 class ChunkSize
 {
     /** @var positive-int */
-    private $chunkSize;
+    private readonly int $chunkSize;
 
     public function __construct(int $chunkSize)
     {

--- a/src/Configuration/DependencyInjection/ParallelContainerDefinition.php
+++ b/src/Configuration/DependencyInjection/ParallelContainerDefinition.php
@@ -38,11 +38,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyEventDi
 
 class ParallelContainerDefinition
 {
-    /** @var ParserDefinition */
-    private $parserDefinition;
+    private readonly ParserDefinition $parserDefinition;
 
-    /** @var TestResultDefinition */
-    private $testResult;
+    private readonly TestResultDefinition $testResult;
 
     public function __construct()
     {

--- a/src/Configuration/DependencyInjection/ParserDefinition.php
+++ b/src/Configuration/DependencyInjection/ParserDefinition.php
@@ -19,6 +19,7 @@ use Paraunit\Parser\ValueObject\TestStatus;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ParserDefinition
@@ -48,7 +49,7 @@ class ParserDefinition
     }
 
     /**
-     * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
+     * @throws BadMethodCallException
      *
      * @return Reference[]
      */

--- a/src/Configuration/EnvVariables.php
+++ b/src/Configuration/EnvVariables.php
@@ -6,11 +6,11 @@ namespace Paraunit\Configuration;
 
 class EnvVariables
 {
-    public const LOG_DIR = 'PARAUNIT_LOG_DIR';
+    final public const LOG_DIR = 'PARAUNIT_LOG_DIR';
 
-    public const PIPELINE_NUMBER = 'PARAUNIT_PIPELINE_NUMBER';
+    final public const PIPELINE_NUMBER = 'PARAUNIT_PIPELINE_NUMBER';
 
-    public const PROCESS_UNIQUE_ID = 'PARAUNIT_PROCESS_UNIQUE_ID';
+    final public const PROCESS_UNIQUE_ID = 'PARAUNIT_PROCESS_UNIQUE_ID';
 
-    public const XDEBUG_MODE = 'XDEBUG_MODE';
+    final public const XDEBUG_MODE = 'XDEBUG_MODE';
 }

--- a/src/Configuration/OutputFile.php
+++ b/src/Configuration/OutputFile.php
@@ -6,8 +6,7 @@ namespace Paraunit\Configuration;
 
 class OutputFile
 {
-    /** @var string */
-    private $filePath;
+    private readonly string $filePath;
 
     public function __construct(string $filePath)
     {

--- a/src/Configuration/OutputPath.php
+++ b/src/Configuration/OutputPath.php
@@ -6,8 +6,7 @@ namespace Paraunit\Configuration;
 
 class OutputPath
 {
-    /** @var string */
-    private $path;
+    private readonly string $path;
 
     public function __construct(string $path)
     {

--- a/src/Configuration/PHPDbgBinFile.php
+++ b/src/Configuration/PHPDbgBinFile.php
@@ -9,7 +9,7 @@ use Symfony\Component\Process\Process;
 class PHPDbgBinFile
 {
     /** @var string Realpath to the PHPDbg bin location */
-    private $phpDbgBin;
+    private readonly string $phpDbgBin;
 
     public function __construct()
     {

--- a/src/Configuration/PHPUnitBinFile.php
+++ b/src/Configuration/PHPUnitBinFile.php
@@ -13,10 +13,9 @@ class PHPUnitBinFile
     private const PHPUNIT_REALPATH_FOR_STANDALONE = '/../../vendor/phpunit/phpunit/phpunit';
 
     /**
-     * @var string Realpath to PHPUnit bin location
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private $phpUnitBin;
+    private ?string $phpUnitBin = null;
 
     /**
      * @throws \RuntimeException If PHPUnit is not found

--- a/src/Configuration/PHPUnitBinFile.php
+++ b/src/Configuration/PHPUnitBinFile.php
@@ -15,7 +15,7 @@ class PHPUnitBinFile
     /**
      * @psalm-suppress PropertyNotSetInConstructor
      */
-    private ?string $phpUnitBin = null;
+    private string $phpUnitBin;
 
     /**
      * @throws \RuntimeException If PHPUnit is not found

--- a/src/Configuration/PHPUnitConfig.php
+++ b/src/Configuration/PHPUnitConfig.php
@@ -53,9 +53,6 @@ class PHPUnitConfig
         return $this->phpunitOptions;
     }
 
-    /**
-     * @return PHPUnitOption
-     */
     public function getPhpunitOption(string $name): ?PHPUnitOption
     {
         return $this->phpunitOptions[$name] ?? null;

--- a/src/Configuration/PHPUnitConfig.php
+++ b/src/Configuration/PHPUnitConfig.php
@@ -6,15 +6,14 @@ namespace Paraunit\Configuration;
 
 class PHPUnitConfig
 {
-    public const DEFAULT_FILE_NAME = 'phpunit.xml';
+    final public const DEFAULT_FILE_NAME = 'phpunit.xml';
 
-    public const FALLBACK_CONFIG_FILE_NAME = 'phpunit.xml.dist';
+    final public const FALLBACK_CONFIG_FILE_NAME = 'phpunit.xml.dist';
 
-    /** @var string */
-    private $configFilename;
+    private readonly string $configFilename;
 
     /** @var PHPUnitOption[] */
-    private $phpunitOptions;
+    private array $phpunitOptions = [];
 
     /**
      * @throws \InvalidArgumentException
@@ -22,7 +21,6 @@ class PHPUnitConfig
     public function __construct(string $inputPathOrFileName)
     {
         $this->configFilename = $this->getConfigFileRealpath($inputPathOrFileName);
-        $this->phpunitOptions = [];
     }
 
     /**

--- a/src/Configuration/PHPUnitOption.php
+++ b/src/Configuration/PHPUnitOption.php
@@ -6,23 +6,13 @@ namespace Paraunit\Configuration;
 
 class PHPUnitOption
 {
-    /** @var string */
-    private $name;
+    private ?string $value = null;
 
-    /** @var string|null */
-    private $shortName;
-
-    /** @var string|null */
-    private $value;
-
-    /** @var bool */
-    private $hasValue;
-
-    public function __construct(string $name, bool $hasValue = true, string $shortName = null)
-    {
-        $this->name = $name;
-        $this->hasValue = $hasValue;
-        $this->shortName = $shortName;
+    public function __construct(
+        private readonly string $name,
+        private readonly bool $hasValue = true,
+        private readonly ?string $shortName = null
+    ) {
     }
 
     public function getName(): string
@@ -35,9 +25,6 @@ class PHPUnitOption
         return $this->shortName;
     }
 
-    /**
-     * @param string $value
-     */
     public function setValue(string $value = null): void
     {
         $this->value = $value;

--- a/src/Configuration/ParallelConfiguration.php
+++ b/src/Configuration/ParallelConfiguration.php
@@ -13,29 +13,25 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ParallelConfiguration
 {
-    public const TAG_EVENT_SUBSCRIBER = 'kernel.event_subscriber';
+    final public const TAG_EVENT_SUBSCRIBER = 'kernel.event_subscriber';
 
-    public const PUBLIC_ALIAS_FORMAT = '%s_public_alias';
+    final public const PUBLIC_ALIAS_FORMAT = '%s_public_alias';
 
-    /** @var ParallelContainerDefinition */
-    protected $containerDefinition;
+    protected ParallelContainerDefinition $containerDefinition;
 
-    /** @var bool */
-    private $createPublicServiceAliases;
-
-    public function __construct(bool $createPublicServiceAliases = false)
+    public function __construct(private readonly bool $createPublicServiceAliases = false)
     {
         $this->containerDefinition = new ParallelContainerDefinition();
-        $this->createPublicServiceAliases = $createPublicServiceAliases;
     }
 
     /**
-     * @throws \Symfony\Component\DependencyInjection\Exception\BadMethodCallException
+     * @throws BadMethodCallException
      * @throws \Exception
      */
     public function buildContainer(InputInterface $input, OutputInterface $output): ContainerBuilder

--- a/src/Configuration/TempFilenameFactory.php
+++ b/src/Configuration/TempFilenameFactory.php
@@ -8,12 +8,8 @@ use Paraunit\File\TempDirectory;
 
 class TempFilenameFactory
 {
-    /** @var TempDirectory */
-    private $tempDirectory;
-
-    public function __construct(TempDirectory $tempDirectory)
+    public function __construct(private readonly TempDirectory $tempDirectory)
     {
-        $this->tempDirectory = $tempDirectory;
     }
 
     /**

--- a/src/Configuration/register_subscribers.php
+++ b/src/Configuration/register_subscribers.php
@@ -1,19 +1,25 @@
 <?php
 
 declare(strict_types=1);
-
-use Paraunit\Parser\TestHook;
+use Paraunit\Parser\TestHook\BeforeTest;
+use Paraunit\Parser\TestHook\Error;
+use Paraunit\Parser\TestHook\Failure;
+use Paraunit\Parser\TestHook\Incomplete;
+use Paraunit\Parser\TestHook\Passed;
+use Paraunit\Parser\TestHook\Risky;
+use Paraunit\Parser\TestHook\Skipped;
+use Paraunit\Parser\TestHook\Warning;
 use PHPUnit\Event\Facade;
 
 // TODO - wait for feedback and refactor accordingly
 // see https://github.com/sebastianbergmann/phpunit/issues/4807
 // or  https://github.com/sebastianbergmann/phpunit/issues/4676
 
-Facade::registerSubscriber(new TestHook\BeforeTest());
-Facade::registerSubscriber(new TestHook\Error());
-Facade::registerSubscriber(new TestHook\Failure());
-Facade::registerSubscriber(new TestHook\Incomplete());
-Facade::registerSubscriber(new TestHook\Risky());
-Facade::registerSubscriber(new TestHook\Skipped());
-Facade::registerSubscriber(new TestHook\Passed());
-Facade::registerSubscriber(new TestHook\Warning());
+Facade::registerSubscriber(new BeforeTest());
+Facade::registerSubscriber(new Error());
+Facade::registerSubscriber(new Failure());
+Facade::registerSubscriber(new Incomplete());
+Facade::registerSubscriber(new Risky());
+Facade::registerSubscriber(new Skipped());
+Facade::registerSubscriber(new Passed());
+Facade::registerSubscriber(new Warning());

--- a/src/Configuration/register_subscribers.php
+++ b/src/Configuration/register_subscribers.php
@@ -1,6 +1,9 @@
 <?php
 
 declare(strict_types=1);
+
+namespace Paraunit\Configuration;
+
 use Paraunit\Parser\TestHook\BeforeTest;
 use Paraunit\Parser\TestHook\Error;
 use Paraunit\Parser\TestHook\Failure;
@@ -14,7 +17,6 @@ use PHPUnit\Event\Facade;
 // TODO - wait for feedback and refactor accordingly
 // see https://github.com/sebastianbergmann/phpunit/issues/4807
 // or  https://github.com/sebastianbergmann/phpunit/issues/4676
-
 Facade::registerSubscriber(new BeforeTest());
 Facade::registerSubscriber(new Error());
 Facade::registerSubscriber(new Failure());

--- a/src/Coverage/CoverageFetcher.php
+++ b/src/Coverage/CoverageFetcher.php
@@ -14,16 +14,10 @@ use Symfony\Component\Process\Process;
 
 class CoverageFetcher
 {
-    /** @var TempFilenameFactory */
-    private $tempFilenameFactory;
-
-    /** @var TestResultHandlerInterface */
-    private $resultHandler;
-
-    public function __construct(TempFilenameFactory $tempFilenameFactory, TestResultHandlerInterface $failureHandler)
-    {
-        $this->tempFilenameFactory = $tempFilenameFactory;
-        $this->resultHandler = $failureHandler;
+    public function __construct(
+        private readonly TempFilenameFactory $tempFilenameFactory,
+        private readonly TestResultHandlerInterface $resultHandler
+    ) {
     }
 
     public function fetch(AbstractParaunitProcess $process): CodeCoverage
@@ -57,7 +51,7 @@ class CoverageFetcher
             $verificationProcess->run();
 
             return $verificationProcess->getExitCode() === 0;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }

--- a/src/Coverage/CoverageMerger.php
+++ b/src/Coverage/CoverageMerger.php
@@ -50,7 +50,7 @@ class CoverageMerger implements EventSubscriberInterface
 
     public function getCoverageData(): CodeCoverage
     {
-        if ($this->coverageData) {
+        if ($this->coverageData !== null) {
             return $this->coverageData;
         }
 

--- a/src/Coverage/CoverageMerger.php
+++ b/src/Coverage/CoverageMerger.php
@@ -11,15 +11,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CoverageMerger implements EventSubscriberInterface
 {
-    /** @var CoverageFetcher */
-    private $coverageFetcher;
+    private ?CodeCoverage $coverageData = null;
 
-    /** @var CodeCoverage|null */
-    private $coverageData;
-
-    public function __construct(CoverageFetcher $coverageFetcher)
+    public function __construct(private readonly CoverageFetcher $coverageFetcher)
     {
-        $this->coverageFetcher = $coverageFetcher;
     }
 
     /**

--- a/src/Coverage/CoverageResult.php
+++ b/src/Coverage/CoverageResult.php
@@ -10,16 +10,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CoverageResult implements EventSubscriberInterface
 {
-    /** @var CoverageMerger */
-    private $coverageMerger;
-
     /** @var CoverageProcessorInterface[] */
-    private $coverageProcessors;
+    private array $coverageProcessors = [];
 
-    public function __construct(CoverageMerger $coverageMerger)
+    public function __construct(private readonly CoverageMerger $coverageMerger)
     {
-        $this->coverageMerger = $coverageMerger;
-        $this->coverageProcessors = [];
     }
 
     /**

--- a/src/Coverage/Processor/AbstractText.php
+++ b/src/Coverage/Processor/AbstractText.php
@@ -12,24 +12,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractText implements CoverageProcessorInterface
 {
-    /** @var PHPUnitText */
-    private $text;
+    private readonly PHPUnitText $text;
 
-    /** @var OutputInterface */
-    private $output;
-
-    /** @var OutputFile|null */
-    private $targetFile;
-
-    /** @var bool */
-    private $showColors;
-
-    public function __construct(OutputInterface $output, bool $showColors, bool $onlySummary, OutputFile $targetFile = null)
-    {
+    public function __construct(
+        private readonly OutputInterface $output,
+        private readonly bool $showColors,
+        bool $onlySummary,
+        private readonly ?OutputFile $targetFile = null
+    ) {
         $this->text = new PHPUnitText(Thresholds::default(), false, $onlySummary);
-        $this->output = $output;
-        $this->targetFile = $targetFile;
-        $this->showColors = $showColors;
     }
 
     /**

--- a/src/Coverage/Processor/AbstractText.php
+++ b/src/Coverage/Processor/AbstractText.php
@@ -30,7 +30,7 @@ abstract class AbstractText implements CoverageProcessorInterface
     {
         $coverageResults = $this->text->process($codeCoverage, $this->showColors);
 
-        if ($this->targetFile) {
+        if ($this->targetFile !== null) {
             file_put_contents($this->targetFile->getFilePath(), $coverageResults);
         } else {
             $this->output->writeln($coverageResults);

--- a/src/Coverage/Processor/Clover.php
+++ b/src/Coverage/Processor/Clover.php
@@ -10,16 +10,11 @@ use SebastianBergmann\CodeCoverage\Report\Clover as PHPUnitClover;
 
 class Clover implements CoverageProcessorInterface
 {
-    /** @var PHPUnitClover */
-    private $clover;
+    private readonly PHPUnitClover $clover;
 
-    /** @var OutputFile */
-    private $targetFile;
-
-    public function __construct(OutputFile $targetFile)
+    public function __construct(private readonly OutputFile $targetFile)
     {
         $this->clover = new PHPUnitClover();
-        $this->targetFile = $targetFile;
     }
 
     /**

--- a/src/Coverage/Processor/Crap4j.php
+++ b/src/Coverage/Processor/Crap4j.php
@@ -10,16 +10,11 @@ use SebastianBergmann\CodeCoverage\Report\Crap4j as PHPUnitCrap4j;
 
 class Crap4j implements CoverageProcessorInterface
 {
-    /** @var PHPUnitCrap4j */
-    private $crap4j;
+    private readonly PHPUnitCrap4j $crap4j;
 
-    /** @var OutputFile */
-    private $targetFile;
-
-    public function __construct(OutputFile $targetFile)
+    public function __construct(private readonly OutputFile $targetFile)
     {
         $this->crap4j = new PHPUnitCrap4j();
-        $this->targetFile = $targetFile;
     }
 
     /**

--- a/src/Coverage/Processor/Html.php
+++ b/src/Coverage/Processor/Html.php
@@ -10,16 +10,11 @@ use SebastianBergmann\CodeCoverage\Report\Html\Facade;
 
 class Html implements CoverageProcessorInterface
 {
-    /** @var Facade */
-    private $html;
+    private readonly Facade $html;
 
-    /** @var OutputPath */
-    private $targetPath;
-
-    public function __construct(OutputPath $targetPath)
+    public function __construct(private readonly OutputPath $targetPath)
     {
         $this->html = new Facade();
-        $this->targetPath = $targetPath;
     }
 
     /**

--- a/src/Coverage/Processor/Php.php
+++ b/src/Coverage/Processor/Php.php
@@ -10,16 +10,11 @@ use SebastianBergmann\CodeCoverage\Report\PHP as PHPUnitPhp;
 
 class Php implements CoverageProcessorInterface
 {
-    /** @var PHPUnitPhp */
-    private $php;
+    private readonly PHPUnitPhp $php;
 
-    /** @var OutputFile */
-    private $targetFile;
-
-    public function __construct(OutputFile $targetFile)
+    public function __construct(private readonly OutputFile $targetFile)
     {
         $this->php = new PHPUnitPhp();
-        $this->targetFile = $targetFile;
     }
 
     /**

--- a/src/Coverage/Processor/Xml.php
+++ b/src/Coverage/Processor/Xml.php
@@ -11,16 +11,11 @@ use SebastianBergmann\CodeCoverage\Report\Xml\Facade;
 
 class Xml implements CoverageProcessorInterface
 {
-    /** @var Facade */
-    private $xml;
+    private readonly Facade $xml;
 
-    /** @var OutputPath */
-    private $targetPath;
-
-    public function __construct(OutputPath $targetPath)
+    public function __construct(private readonly OutputPath $targetPath)
     {
         $this->xml = new Facade(Version::id());
-        $this->targetPath = $targetPath;
     }
 
     /**

--- a/src/File/Cleaner.php
+++ b/src/File/Cleaner.php
@@ -10,12 +10,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class Cleaner implements EventSubscriberInterface
 {
-    /** @var TempDirectory */
-    private $tempDirectory;
-
-    public function __construct(TempDirectory $tempDirectory)
+    public function __construct(private readonly TempDirectory $tempDirectory)
     {
-        $this->tempDirectory = $tempDirectory;
     }
 
     /**

--- a/src/File/TempDirectory.php
+++ b/src/File/TempDirectory.php
@@ -7,12 +7,11 @@ namespace Paraunit\File;
 class TempDirectory
 {
     /** @var string[] */
-    private static $tempDirs = [
+    private static array $tempDirs = [
         '/dev/shm',
     ];
 
-    /** @var string */
-    private static $timestamp;
+    private static string $timestamp;
 
     public function __construct()
     {
@@ -50,7 +49,7 @@ class TempDirectory
                     self::mkdirIfNotExists($baseDir);
 
                     return $baseDir;
-                } catch (\RuntimeException $e) {
+                } catch (\RuntimeException) {
                     // ignore and try next dir
                 }
             }

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -12,7 +12,6 @@ class Filter
 {
     private readonly Loader $xmlLoader;
 
-    /** @var string | null */
     private readonly string $relativePath;
 
     public function __construct(
@@ -166,7 +165,7 @@ class Filter
     private function filterByString(array $aggregatedFiles, ?string $stringFilter): array
     {
         if ($stringFilter !== null) {
-            $aggregatedFiles = array_filter($aggregatedFiles, fn ($value) => stripos((string) $value, $stringFilter) !== false);
+            $aggregatedFiles = array_filter($aggregatedFiles, fn ($value): bool => stripos($value, $stringFilter) !== false);
         }
 
         return array_values($aggregatedFiles);

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -146,7 +146,7 @@ class Filter
         string $defaultValue = null
     ): string {
         /** @psalm-suppress RedundantCondition */
-        if ($testSuiteNode->attributes) {
+        if ($testSuiteNode->attributes !== null) {
             foreach ($testSuiteNode->attributes as $attrName => $attrNode) {
                 if ($attrName === $nodeName) {
                     return $attrNode->value;

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -10,37 +10,20 @@ use SebastianBergmann\FileIterator\Facade;
 
 class Filter
 {
-    /** @var Loader */
-    private $xmlLoader;
-
-    /** @var Facade */
-    private $fileIteratorFacade;
-
-    /** @var PHPUnitConfig */
-    private $configFile;
+    private readonly Loader $xmlLoader;
 
     /** @var string | null */
-    private $relativePath;
-
-    /** @var string | null */
-    private $testSuiteFilter;
-
-    /** @var string | null */
-    private $stringFilter;
+    private readonly string $relativePath;
 
     public function __construct(
-        Facade $fileIteratorFacade,
-        PHPUnitConfig $configFile,
-        string $testSuiteFilter = null,
-        string $stringFilter = null
+        private readonly Facade $fileIteratorFacade,
+        private readonly PHPUnitConfig $configFile,
+        private readonly ?string $testSuiteFilter = null,
+        private readonly ?string $stringFilter = null
     ) {
         /** @psalm-suppress InternalClass */
         $this->xmlLoader = new Loader();
-        $this->fileIteratorFacade = $fileIteratorFacade;
-        $this->configFile = $configFile;
         $this->relativePath = $configFile->getBaseDirectory() . DIRECTORY_SEPARATOR;
-        $this->testSuiteFilter = $testSuiteFilter;
-        $this->stringFilter = $stringFilter;
     }
 
     /**
@@ -64,7 +47,7 @@ class Filter
 
         foreach ($nodeList as $testSuiteNode) {
             if (! $testSuiteNode instanceof \DOMElement) {
-                throw new \InvalidArgumentException('Invalid DOM subtype in PHPUnit configuration, expeding \DOMElement, got ' . get_class($testSuiteNode));
+                throw new \InvalidArgumentException('Invalid DOM subtype in PHPUnit configuration, expeding \DOMElement, got ' . $testSuiteNode::class);
             }
 
             if ($this->testSuitePassFilter($testSuiteNode, $this->testSuiteFilter)) {
@@ -183,9 +166,7 @@ class Filter
     private function filterByString(array $aggregatedFiles, ?string $stringFilter): array
     {
         if ($stringFilter !== null) {
-            $aggregatedFiles = array_filter($aggregatedFiles, function ($value) use ($stringFilter) {
-                return stripos($value, $stringFilter) !== false;
-            });
+            $aggregatedFiles = array_filter($aggregatedFiles, fn ($value) => stripos((string) $value, $stringFilter) !== false);
         }
 
         return array_values($aggregatedFiles);

--- a/src/Lifecycle/AbstractProcessEvent.php
+++ b/src/Lifecycle/AbstractProcessEvent.php
@@ -8,12 +8,8 @@ use Paraunit\Process\AbstractParaunitProcess;
 
 abstract class AbstractProcessEvent extends AbstractEvent
 {
-    /** @var AbstractParaunitProcess */
-    private $process;
-
-    public function __construct(AbstractParaunitProcess $process)
+    public function __construct(private readonly AbstractParaunitProcess $process)
     {
-        $this->process = $process;
     }
 
     public function getProcess(): AbstractParaunitProcess

--- a/src/Parser/JSON/AbnormalTerminatedParser.php
+++ b/src/Parser/JSON/AbnormalTerminatedParser.php
@@ -58,11 +58,9 @@ class AbnormalTerminatedParser extends GenericParser
             return;
         }
 
-        if ($this->chunkSize->isChunked()) {
-            $suiteName = basename($process->getFilename());
-        } else {
-            $suiteName = explode('::', $logItem->test->name)[0];
-        }
+        $suiteName = $this->chunkSize->isChunked() 
+            ? basename($process->getFilename()) 
+            : explode('::', $logItem->test->name)[0];
 
         $process->setTestClassName($suiteName);
     }

--- a/src/Parser/JSON/LogParser.php
+++ b/src/Parser/JSON/LogParser.php
@@ -17,32 +17,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class LogParser implements EventSubscriberInterface
 {
-    /** @var LogFetcher */
-    private $logLocator;
-
-    /** @var TestResultHandlerInterface */
-    private $noTestExecutedResultContainer;
-
-    /** @var EventDispatcherInterface */
-    private $eventDispatcher;
-
-    /** @var RetryParser */
-    private $retryParser;
-
     /** @var ParserChainElementInterface[] */
-    private $parsers;
+    private array $parsers = [];
 
-    public function __construct(
-        LogFetcher $logLocator,
-        TestResultHandlerInterface $noTestExecutedResultContainer,
-        EventDispatcherInterface $eventDispatcher,
-        RetryParser $retryParser
-    ) {
-        $this->logLocator = $logLocator;
-        $this->noTestExecutedResultContainer = $noTestExecutedResultContainer;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->retryParser = $retryParser;
-        $this->parsers = [];
+    public function __construct(private readonly LogFetcher $logLocator, private readonly TestResultHandlerInterface $noTestExecutedResultContainer, private readonly EventDispatcherInterface $eventDispatcher, private readonly RetryParser $retryParser)
+    {
     }
 
     /**

--- a/src/Parser/JSON/WarningParser.php
+++ b/src/Parser/JSON/WarningParser.php
@@ -20,7 +20,7 @@ class WarningParser extends GenericParser
     public function handleLogItem(AbstractParaunitProcess $process, LogData $logItem): ?TestResultInterface
     {
         $testResult = parent::handleLogItem($process, $logItem);
-        if ($testResult) {
+        if ($testResult !== null) {
             $process->setWaitingForTestResult(true);
         }
 

--- a/src/Printer/AbstractFinalPrinter.php
+++ b/src/Printer/AbstractFinalPrinter.php
@@ -10,20 +10,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractFinalPrinter extends AbstractPrinter
 {
-    /** @var TestResultList */
-    protected $testResultList;
-
-    /** @var ChunkSize */
-    protected $chunkSize;
-
     public function __construct(
-        TestResultList $testResultList,
+        protected TestResultList $testResultList,
         OutputInterface $output,
-        ChunkSize $chunkSize
+        protected ChunkSize $chunkSize
     ) {
         parent::__construct($output);
-        $this->testResultList = $testResultList;
-        $this->chunkSize = $chunkSize;
     }
 
     abstract public function onEngineEnd(): void;

--- a/src/Printer/AbstractPrinter.php
+++ b/src/Printer/AbstractPrinter.php
@@ -8,12 +8,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractPrinter
 {
-    /** @var OutputInterface */
-    private $output;
-
-    public function __construct(OutputInterface $output)
+    public function __construct(private readonly OutputInterface $output)
     {
-        $this->output = $output;
     }
 
     public function getOutput(): OutputInterface

--- a/src/Printer/FilesRecapPrinter.php
+++ b/src/Printer/FilesRecapPrinter.php
@@ -35,13 +35,9 @@ class FilesRecapPrinter extends AbstractFinalPrinter implements EventSubscriberI
         }
 
         $filenames = $testResultContainer->getFileNames();
-        if ($this->chunkSize->isChunked()) {
-            $fileTitle = 'chunks';
-        } else {
-            $fileTitle = 'files';
-        }
+        $fileTitle = $this->chunkSize->isChunked() ? 'chunks' : 'files';
 
-        if (count($filenames)) {
+        if (count($filenames) > 0) {
             $tag = $testResultContainer->getTestResultFormat()->getTag();
             $title = $testResultContainer->getTestResultFormat()->getTitle();
             $this->getOutput()->writeln('');

--- a/src/Printer/FinalPrinter.php
+++ b/src/Printer/FinalPrinter.php
@@ -10,7 +10,6 @@ use Paraunit\Lifecycle\EngineEnd;
 use Paraunit\Lifecycle\EngineStart;
 use Paraunit\Lifecycle\ProcessTerminated;
 use Paraunit\Lifecycle\ProcessToBeRetried;
-use Paraunit\TestResult\Interfaces\TestResultContainerInterface;
 use Paraunit\TestResult\TestResultList;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -84,9 +83,7 @@ class FinalPrinter extends AbstractFinalPrinter implements EventSubscriberInterf
     {
         $testsCount = 0;
         foreach ($this->testResultList->getTestResultContainers() as $container) {
-            if ($container instanceof TestResultContainerInterface) {
-                $testsCount += $container->countTestResults();
-            }
+            $testsCount += $container->countTestResults();
         }
 
         $this->getOutput()->writeln('');

--- a/src/Printer/FinalPrinter.php
+++ b/src/Printer/FinalPrinter.php
@@ -88,11 +88,7 @@ class FinalPrinter extends AbstractFinalPrinter implements EventSubscriberInterf
 
         $this->getOutput()->writeln('');
         $executedNum = $this->processCompleted - $this->processRetried;
-        if ($this->chunkSize->isChunked()) {
-            $executedTitle = 'chunks';
-        } else {
-            $executedTitle = 'test classes';
-        }
+        $executedTitle = $this->chunkSize->isChunked() ? 'chunks' : 'test classes';
         $this->getOutput()->write(sprintf("Executed: %d $executedTitle", $executedNum));
         if ($this->processRetried > 0) {
             $this->getOutput()->write(sprintf(' (%d retried)', $this->processRetried));

--- a/src/Printer/FinalPrinter.php
+++ b/src/Printer/FinalPrinter.php
@@ -21,14 +21,11 @@ class FinalPrinter extends AbstractFinalPrinter implements EventSubscriberInterf
 {
     private const STOPWATCH_NAME = 'engine';
 
-    /** @var Stopwatch */
-    private $stopWatch;
+    private readonly Stopwatch $stopWatch;
 
-    /** @var int */
-    private $processCompleted;
+    private int $processCompleted = 0;
 
-    /** @var int */
-    private $processRetried;
+    private int $processRetried = 0;
 
     public function __construct(
         TestResultList $testResultList,
@@ -38,8 +35,6 @@ class FinalPrinter extends AbstractFinalPrinter implements EventSubscriberInterf
         parent::__construct($testResultList, $output, $chunkSize);
 
         $this->stopWatch = new Stopwatch();
-        $this->processCompleted = 0;
-        $this->processRetried = 0;
     }
 
     /**

--- a/src/Printer/ProcessPrinter.php
+++ b/src/Printer/ProcessPrinter.php
@@ -15,28 +15,16 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ProcessPrinter implements EventSubscriberInterface
 {
-    public const MAX_CHAR_LENGTH = 80;
+    final public const MAX_CHAR_LENGTH = 80;
 
     private const COUNTER_CHAR_LENGTH = 5;
 
-    /** @var SingleResultFormatter */
-    private $singleResultFormatter;
+    private int $counter = 0;
 
-    /** @var OutputInterface */
-    private $output;
+    private int $singleRowCounter = 0;
 
-    /** @var int */
-    private $counter;
-
-    /** @var int */
-    private $singleRowCounter;
-
-    public function __construct(SingleResultFormatter $singleResultFormatter, OutputInterface $output)
+    public function __construct(private readonly SingleResultFormatter $singleResultFormatter, private readonly OutputInterface $output)
     {
-        $this->singleResultFormatter = $singleResultFormatter;
-        $this->output = $output;
-        $this->counter = 0;
-        $this->singleRowCounter = 0;
     }
 
     /**

--- a/src/Printer/SharkPrinter.php
+++ b/src/Printer/SharkPrinter.php
@@ -12,14 +12,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class SharkPrinter extends AbstractPrinter implements EventSubscriberInterface
 {
-    /** @var bool */
-    private $showLogo;
-
-    public function __construct(OutputInterface $output, bool $showLogo)
+    public function __construct(OutputInterface $output, private readonly bool $showLogo)
     {
         parent::__construct($output);
-
-        $this->showLogo = $showLogo;
     }
 
     /**

--- a/src/Printer/SingleResultFormatter.php
+++ b/src/Printer/SingleResultFormatter.php
@@ -11,12 +11,10 @@ use Paraunit\TestResult\TestResultWithSymbolFormat;
 class SingleResultFormatter
 {
     /** @var array<string, string> */
-    private $tagMap;
+    private array $tagMap = [];
 
     public function __construct(TestResultList $testResultList)
     {
-        $this->tagMap = [];
-
         foreach ($testResultList->getTestResultContainers() as $parser) {
             $format = $parser->getTestResultFormat();
             if ($format instanceof TestResultWithSymbolFormat) {

--- a/src/Process/AbstractParaunitProcess.php
+++ b/src/Process/AbstractParaunitProcess.php
@@ -16,20 +16,15 @@ abstract class AbstractParaunitProcess extends AbstractInfo
 
     protected string $uniqueId;
 
-    /** @var string */
-    protected $filename;
-
-    /** @var string|null */
-    protected $testClassName = null;
+    protected ?string $testClassName = null;
 
     /** @var PrintableTestResultInterface[] */
     protected array $testResults = [];
 
     private bool $waitingForTestResult = true;
 
-    public function __construct(string $filename)
+    public function __construct(protected string $filename)
     {
-        $this->filename = $filename;
         $this->uniqueId = md5($this->filename);
     }
 

--- a/src/Process/AbstractParaunitProcess.php
+++ b/src/Process/AbstractParaunitProcess.php
@@ -12,11 +12,9 @@ abstract class AbstractParaunitProcess extends AbstractInfo
     /** @var int */
     protected $retryCount = 0;
 
-    /** @var bool */
-    protected $shouldBeRetried;
+    protected bool $shouldBeRetried = false;
 
-    /** @var string */
-    protected $uniqueId;
+    protected string $uniqueId;
 
     /** @var string */
     protected $filename;
@@ -25,18 +23,14 @@ abstract class AbstractParaunitProcess extends AbstractInfo
     protected $testClassName = null;
 
     /** @var PrintableTestResultInterface[] */
-    protected $testResults;
+    protected array $testResults = [];
 
-    /** @var bool */
-    private $waitingForTestResult;
+    private bool $waitingForTestResult = true;
 
     public function __construct(string $filename)
     {
         $this->filename = $filename;
         $this->uniqueId = md5($this->filename);
-        $this->testResults = [];
-        $this->waitingForTestResult = true;
-        $this->shouldBeRetried = false;
     }
 
     abstract public function start(int $pipelineNumber): void;

--- a/src/Process/CommandLine.php
+++ b/src/Process/CommandLine.php
@@ -11,18 +11,10 @@ use Paraunit\Configuration\PHPUnitOption;
 
 class CommandLine
 {
-    /** @var PHPUnitBinFile */
-    protected $phpUnitBin;
-
-    /** @var ChunkSize */
-    protected $chunkSize;
-
     public function __construct(
-        PHPUnitBinFile $phpUnitBin,
-        ChunkSize $chunkSize
+        protected PHPUnitBinFile $phpUnitBin,
+        protected ChunkSize $chunkSize
     ) {
-        $this->phpUnitBin = $phpUnitBin;
-        $this->chunkSize = $chunkSize;
     }
 
     /**

--- a/src/Process/ProcessFactory.php
+++ b/src/Process/ProcessFactory.php
@@ -13,31 +13,23 @@ use Symfony\Component\Process\Process;
 
 class ProcessFactory implements ProcessFactoryInterface
 {
-    /** @var CommandLine */
-    private $cliCommand;
-
     /** @var string[] */
-    private $baseCommandLine;
+    private readonly array $baseCommandLine;
 
     /** @var string[] */
     public readonly array $environmentVariables;
 
-    /** @var ChunkSize */
-    private $chunkSize;
-
     public function __construct(
-        CommandLine $cliCommand,
+        private readonly CommandLine $cliCommand,
         PHPUnitConfig $phpunitConfig,
         TempFilenameFactory $tempFilenameFactory,
-        ChunkSize $chunkSize
+        private readonly ChunkSize $chunkSize
     ) {
-        $this->cliCommand = $cliCommand;
         $this->baseCommandLine = array_merge($this->cliCommand->getExecutable(), $this->cliCommand->getOptions($phpunitConfig));
         $this->environmentVariables = [
             EnvVariables::LOG_DIR => $tempFilenameFactory->getPathForLog(),
             EnvVariables::XDEBUG_MODE => $this->getDesiredXdebugMode(),
         ];
-        $this->chunkSize = $chunkSize;
     }
 
     private function getDesiredXdebugMode(): string

--- a/src/Process/SymfonyProcessWrapper.php
+++ b/src/Process/SymfonyProcessWrapper.php
@@ -5,20 +5,18 @@ declare(strict_types=1);
 namespace Paraunit\Process;
 
 use Paraunit\Configuration\EnvVariables;
+use Symfony\Component\Process\Exception\LogicException;
+use Symfony\Component\Process\Exception\RuntimeException;
 use Symfony\Component\Process\Process;
 
 class SymfonyProcessWrapper extends AbstractParaunitProcess
 {
-    /** @var Process */
-    private $process;
-
     /**
      * {@inheritdoc}
      */
-    public function __construct(Process $process, string $filename)
+    public function __construct(private readonly Process $process, string $filename)
     {
         parent::__construct($filename);
-        $this->process = $process;
     }
 
     public function isTerminated(): bool
@@ -38,7 +36,7 @@ class SymfonyProcessWrapper extends AbstractParaunitProcess
     }
 
     /**
-     * @throws \Symfony\Component\Process\Exception\LogicException
+     * @throws LogicException
      */
     public function getOutput(): string
     {
@@ -46,7 +44,7 @@ class SymfonyProcessWrapper extends AbstractParaunitProcess
     }
 
     /**
-     * @throws \Symfony\Component\Process\Exception\LogicException
+     * @throws LogicException
      */
     public function getErrorOutput(): string
     {
@@ -54,7 +52,7 @@ class SymfonyProcessWrapper extends AbstractParaunitProcess
     }
 
     /**
-     * @throws \Symfony\Component\Process\Exception\RuntimeException
+     * @throws RuntimeException
      */
     public function getExitCode(): ?int
     {

--- a/src/Runner/ChunkFile.php
+++ b/src/Runner/ChunkFile.php
@@ -39,7 +39,7 @@ class ChunkFile
         $nodeList = iterator_to_array($nodeList);
         $testSuitesNode = array_shift($nodeList);
 
-        if (null === $testSuitesNode) {
+        if (! $testSuitesNode instanceof \DOMNode) {
             throw new \InvalidArgumentException('Expecting \DOMElement, got null');
         }
 

--- a/src/Runner/ChunkFile.php
+++ b/src/Runner/ChunkFile.php
@@ -10,17 +10,12 @@ use PHPUnit\Util\Xml\Loader;
 
 class ChunkFile
 {
-    /** @var Loader */
-    private $xmlLoader;
+    private readonly Loader $xmlLoader;
 
-    /** @var PHPUnitConfig */
-    private $phpunitConfig;
-
-    public function __construct(PHPUnitConfig $phpunitConfig)
+    public function __construct(private readonly PHPUnitConfig $phpunitConfig)
     {
         /** @psalm-suppress InternalClass */
         $this->xmlLoader = new Loader();
-        $this->phpunitConfig = $phpunitConfig;
     }
 
     /**

--- a/src/Runner/Pipeline.php
+++ b/src/Runner/Pipeline.php
@@ -38,7 +38,7 @@ class Pipeline
 
     public function isTerminated(): bool
     {
-        if ($this->process) {
+        if ($this->process !== null) {
             return $this->process->isTerminated();
         }
 
@@ -72,7 +72,7 @@ class Pipeline
 
     private function handleProcessTermination(): void
     {
-        if ($this->process) {
+        if ($this->process !== null) {
             $this->dispatcher->dispatch(new ProcessTerminated($this->process));
             $this->process = null;
         }

--- a/src/Runner/Pipeline.php
+++ b/src/Runner/Pipeline.php
@@ -65,10 +65,7 @@ class Pipeline
         return $this->number;
     }
 
-    /**
-     * @return AbstractParaunitProcess|null
-     */
-    public function getProcess()
+    public function getProcess(): ?AbstractParaunitProcess
     {
         return $this->process;
     }

--- a/src/Runner/Pipeline.php
+++ b/src/Runner/Pipeline.php
@@ -11,19 +11,12 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 
 class Pipeline
 {
-    /** @var EventDispatcherInterface */
-    private $dispatcher;
+    private ?AbstractParaunitProcess $process = null;
 
-    /** @var AbstractParaunitProcess|null */
-    private $process;
-
-    /** @var int */
-    private $number;
-
-    public function __construct(EventDispatcherInterface $dispatcher, int $number)
-    {
-        $this->dispatcher = $dispatcher;
-        $this->number = $number;
+    public function __construct(
+        private readonly EventDispatcherInterface $dispatcher,
+        private readonly int $number
+    ) {
     }
 
     public function execute(AbstractParaunitProcess $process): void

--- a/src/Runner/PipelineCollection.php
+++ b/src/Runner/PipelineCollection.php
@@ -9,12 +9,10 @@ use Paraunit\Process\AbstractParaunitProcess;
 class PipelineCollection
 {
     /** @var Pipeline[] */
-    private $pipelines;
+    private array $pipelines = [];
 
     public function __construct(PipelineFactory $pipelineFactory, int $maxProcessNumber = 10)
     {
-        $this->pipelines = [];
-
         for ($pipelineNumber = 1; $pipelineNumber <= $maxProcessNumber; ++$pipelineNumber) {
             $this->pipelines[] = $pipelineFactory->create($pipelineNumber);
         }

--- a/src/Runner/PipelineCollection.php
+++ b/src/Runner/PipelineCollection.php
@@ -64,7 +64,7 @@ class PipelineCollection
         $processes = [];
         foreach ($this->pipelines as $pipeline) {
             $process = $pipeline->getProcess();
-            if ($process) {
+            if ($process !== null) {
                 $processes[] = $process;
             }
         }

--- a/src/Runner/PipelineFactory.php
+++ b/src/Runner/PipelineFactory.php
@@ -8,12 +8,8 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 
 class PipelineFactory
 {
-    /** @var EventDispatcherInterface */
-    private $dispatcher;
-
-    public function __construct(EventDispatcherInterface $dispatcher)
+    public function __construct(private readonly EventDispatcherInterface $dispatcher)
     {
-        $this->dispatcher = $dispatcher;
     }
 
     public function create(int $pipelineNumber): Pipeline

--- a/src/TestResult/TestResultContainer.php
+++ b/src/TestResult/TestResultContainer.php
@@ -14,31 +14,14 @@ use Paraunit\TestResult\Interfaces\TestResultInterface;
 
 class TestResultContainer implements TestResultContainerInterface, TestResultHandlerInterface
 {
-    /** @var TestResultFormat */
-    private $testResultFormat;
-
-    /** @var PHPUnitConfig */
-    private $config;
-
-    /** @var ChunkSize */
-    private $chunkSize;
-
     /** @var string[] */
-    private $filenames;
+    private array $filenames = [];
 
     /** @var PrintableTestResultInterface[] */
-    private $testResults;
+    private array $testResults = [];
 
-    public function __construct(
-        TestResultFormat $testResultFormat,
-        PHPUnitConfig $config,
-        ChunkSize $chunkSize
-    ) {
-        $this->testResultFormat = $testResultFormat;
-        $this->config = $config;
-        $this->chunkSize = $chunkSize;
-        $this->filenames = [];
-        $this->testResults = [];
+    public function __construct(private readonly TestResultFormat $testResultFormat, private readonly PHPUnitConfig $config, private readonly ChunkSize $chunkSize)
+    {
     }
 
     public function handleTestResult(AbstractParaunitProcess $process, TestResultInterface $testResult): void

--- a/src/TestResult/TestResultContainer.php
+++ b/src/TestResult/TestResultContainer.php
@@ -87,8 +87,8 @@ class TestResultContainer implements TestResultContainerInterface, TestResultHan
     ): void {
         $tag = $this->testResultFormat->getTag();
 
-        $output = $this->config->getPhpunitOption('stderr') ?
-            $process->getErrorOutput()
+        $output = $this->config->getPhpunitOption('stderr') !== null 
+            ? $process->getErrorOutput()
             : $process->getOutput();
 
         $output = $output ?: sprintf('<%s><[NO OUTPUT FOUND]></%s>', $tag, $tag);

--- a/src/TestResult/TestResultFormat.php
+++ b/src/TestResult/TestResultFormat.php
@@ -6,24 +6,8 @@ namespace Paraunit\TestResult;
 
 class TestResultFormat
 {
-    /** @var string */
-    private $tag;
-
-    /** @var string */
-    private $title;
-
-    /** @var bool */
-    private $printTestOutput;
-
-    /** @var bool */
-    private $printFilesRecap;
-
-    public function __construct(string $tag, string $title, bool $printTestOutput = true, bool $printFilesRecap = true)
+    public function __construct(private readonly string $tag, private readonly string $title, private readonly bool $printTestOutput = true, private readonly bool $printFilesRecap = true)
     {
-        $this->tag = $tag;
-        $this->title = $title;
-        $this->printTestOutput = $printTestOutput;
-        $this->printFilesRecap = $printFilesRecap;
     }
 
     public function getTag(): string

--- a/src/TestResult/TestResultList.php
+++ b/src/TestResult/TestResultList.php
@@ -7,11 +7,10 @@ namespace Paraunit\TestResult;
 class TestResultList
 {
     /** @var TestResultContainer[] */
-    private $testResultContainers;
+    private array $testResultContainers = [];
 
     public function __construct()
     {
-        $this->testResultContainers = [];
     }
 
     public function addContainer(TestResultContainer $container): void

--- a/src/TestResult/TestResultList.php
+++ b/src/TestResult/TestResultList.php
@@ -9,10 +9,6 @@ class TestResultList
     /** @var TestResultContainer[] */
     private array $testResultContainers = [];
 
-    public function __construct()
-    {
-    }
-
     public function addContainer(TestResultContainer $container): void
     {
         $this->testResultContainers[] = $container;

--- a/src/TestResult/TestResultWithSymbolFormat.php
+++ b/src/TestResult/TestResultWithSymbolFormat.php
@@ -6,18 +6,14 @@ namespace Paraunit\TestResult;
 
 class TestResultWithSymbolFormat extends TestResultFormat
 {
-    /** @var string */
-    private $testResultSymbol;
-
     public function __construct(
-        string $testResultSymbol,
+        private readonly string $testResultSymbol,
         string $tag,
         string $title,
         bool $printTestOutput = true,
         bool $printFilesRecap = true
     ) {
         parent::__construct($tag, $title, $printTestOutput, $printFilesRecap);
-        $this->testResultSymbol = $testResultSymbol;
     }
 
     public function getTestResultSymbol(): string

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -20,8 +20,7 @@ use Tests\Stub\UnformattedOutputStub;
 
 abstract class BaseIntegrationTestCase extends BaseTestCase
 {
-    /** @var ContainerBuilder|null */
-    private $container;
+    private ?ContainerBuilder $container = null;
 
     /** @var ParallelConfiguration */
     protected $configuration;
@@ -30,14 +29,13 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
     protected $textFilter;
 
     /** @var string[] */
-    private $options;
+    private array $options = [];
 
     public function __construct(string $name)
     {
         parent::__construct($name);
 
         $this->configuration = new ParallelConfiguration(true);
-        $this->options = [];
         $this->setOption('configuration', $this->getStubPath() . DIRECTORY_SEPARATOR . 'phpunit_for_stubs.xml');
     }
 
@@ -147,10 +145,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
         return $service;
     }
 
-    /**
-     * @return int|string
-     */
-    public function getParameter(string $parameterName)
+    public function getParameter(string $parameterName): int|string
     {
         if ($this->container) {
             /** @var int|string */

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -22,8 +22,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
 {
     private ?ContainerBuilder $container = null;
 
-    /** @var ParallelConfiguration */
-    protected $configuration;
+    protected ParallelConfiguration $configuration;
 
     /** @var string */
     protected $textFilter;
@@ -145,11 +144,13 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
         return $service;
     }
 
-    public function getParameter(string $parameterName): int|string
+    protected function getParameter(string $parameterName): bool|int|float|string
     {
         if ($this->container) {
-            /** @var int|string */
-            return $this->container->getParameter($parameterName);
+            $unitEnum = $this->container->getParameter($parameterName);
+            $this->assertIsScalar($unitEnum);
+
+            return $unitEnum;
         }
 
         throw new \RuntimeException('Container not ready');

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -66,7 +66,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
 
     protected function cleanUpTempDirForThisExecution(): void
     {
-        if ($this->container) {
+        if ($this->container !== null) {
             /** @var TempDirectory $tempDirectory */
             $tempDirectory = $this->getService(TempDirectory::class);
             Cleaner::cleanUpDir($tempDirectory->getTempDirForThisExecution());
@@ -131,7 +131,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
      */
     public function getService(string $serviceName): object
     {
-        if (! $this->container) {
+        if ($this->container === null) {
             throw new \RuntimeException('Container not ready');
         }
 
@@ -146,7 +146,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
 
     protected function getParameter(string $parameterName): bool|int|float|string
     {
-        if ($this->container) {
+        if ($this->container !== null) {
             $unitEnum = $this->container->getParameter($parameterName);
             $this->assertIsScalar($unitEnum);
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -16,8 +16,7 @@ class BaseTestCase extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var string|null */
-    private $randomTempDir;
+    private ?string $randomTempDir = null;
 
     protected function getCoverageStubFilePath(): string
     {

--- a/tests/BaseUnitTestCase.php
+++ b/tests/BaseUnitTestCase.php
@@ -21,7 +21,7 @@ abstract class BaseUnitTestCase extends BaseTestCase
     {
         $jsonLogs = JSONLogStub::getCleanOutputFileContent(JSONLogStub::ONE_ERROR);
         /** @var \stdClass[] $logs */
-        $logs = json_decode($jsonLogs);
+        $logs = json_decode($jsonLogs, null, 512, JSON_THROW_ON_ERROR);
         foreach ($logs as $log) {
             if ($log->event === $event) {
                 if ($testOutput) {

--- a/tests/Functional/Runner/RunnerTest.php
+++ b/tests/Functional/Runner/RunnerTest.php
@@ -112,7 +112,7 @@ class RunnerTest extends BaseIntegrationTestCase
         );
     }
 
-    public function testWarning(): void
+    public function testWarning(): never
     {
         $this->setTextFilter('IntentionalWarningTestStub.php');
         $this->loadContainer();
@@ -155,7 +155,7 @@ class RunnerTest extends BaseIntegrationTestCase
         $this->assertStringContainsString('ThreeGreenTestStub.php', $output);
     }
 
-    public function testWarningsToStdout(): void
+    public function testWarningsToStdout(): never
     {
         $this->setTextFilter('SessionTestStub.php');
         $this->loadContainer();
@@ -180,7 +180,7 @@ class RunnerTest extends BaseIntegrationTestCase
         $this->assertStringContainsString('Executed: 1 test classes, 3 tests', $output->getOutput());
     }
 
-    public function testSessionStderr(): void
+    public function testSessionStderr(): never
     {
         $this->setTextFilter('SessionTestStub.php');
         $this->loadContainer();

--- a/tests/Stub/CoverageOutput/Coverage4Stub.php
+++ b/tests/Stub/CoverageOutput/Coverage4Stub.php
@@ -1,10 +1,10 @@
 <?php
 
+namespace Tests\Stub\CoverageOutput;
+
 use Paraunit\Proxy\Coverage\FakeDriver;
 use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Filter;
-
 $codeCoverage = new CodeCoverage(new FakeDriver(), new Filter());
 $codeCoverage->setTests(['foo' => 'bar']);
-
 return $codeCoverage;

--- a/tests/Stub/CoverageOutput/WrongCoverageStub.php
+++ b/tests/Stub/CoverageOutput/WrongCoverageStub.php
@@ -2,4 +2,6 @@
 
 declare(strict_types=1);
 
+namespace Tests\Stub\CoverageOutput;
+
 return new \DateTime();

--- a/tests/Stub/EntityManagerClosedTestStub.php
+++ b/tests/Stub/EntityManagerClosedTestStub.php
@@ -6,12 +6,12 @@ namespace Tests\Stub;
 
 class EntityManagerClosedTestStub extends BrokenTestBase implements BrokenTestInterface
 {
-    public const OUTPUT = 'Blah Blah The EntityManager is closed Blah Blah';
+    final public const OUTPUT = 'Blah Blah The EntityManager is closed Blah Blah';
 
     /**
      * @throws \Exception
      */
-    public function testBrokenTest()
+    public function testBrokenTest(): never
     {
         throw new \Exception(self::OUTPUT);
     }

--- a/tests/Stub/FatalErrorTestStub.php
+++ b/tests/Stub/FatalErrorTestStub.php
@@ -11,7 +11,7 @@ class FatalErrorTestStub extends BrokenTestBase implements BrokenTestInterface
         $foo = new class() implements \JsonSerializable {
         };
 
-        $message = 'This assertion should not happen: ' . json_encode($foo);
+        $message = 'This assertion should not happen: ' . json_encode($foo, JSON_THROW_ON_ERROR);
 
         self::assertTrue(true, $message);
     }

--- a/tests/Stub/MySQLDeadLockTestStub.php
+++ b/tests/Stub/MySQLDeadLockTestStub.php
@@ -6,12 +6,12 @@ namespace Tests\Stub;
 
 class MySQLDeadLockTestStub extends BrokenTestBase implements BrokenTestInterface
 {
-    public const OUTPUT = 'SQLSTATE[HY000]: General error: Deadlock found; try restarting transaction';
+    final public const OUTPUT = 'SQLSTATE[HY000]: General error: Deadlock found; try restarting transaction';
 
     /**
      * @throws \Exception
      */
-    public function testBrokenTest()
+    public function testBrokenTest(): never
     {
         throw new \Exception(self::OUTPUT);
     }

--- a/tests/Stub/MySQLLockTimeoutTestStub.php
+++ b/tests/Stub/MySQLLockTimeoutTestStub.php
@@ -6,12 +6,12 @@ namespace Tests\Stub;
 
 class MySQLLockTimeoutTestStub extends BrokenTestBase implements BrokenTestInterface
 {
-    public const OUTPUT = 'SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction';
+    final public const OUTPUT = 'SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction';
 
     /**
      * @throws \Exception
      */
-    public function testBrokenTest()
+    public function testBrokenTest(): never
     {
         throw new \Exception(self::OUTPUT);
     }

--- a/tests/Stub/MySQLSavePointMissingTestStub.php
+++ b/tests/Stub/MySQLSavePointMissingTestStub.php
@@ -6,12 +6,12 @@ namespace Tests\Stub;
 
 class MySQLSavePointMissingTestStub extends BrokenTestBase implements BrokenTestInterface
 {
-    public const OUTPUT = 'SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT DOCTRINE2_SAVEPOINT_2 does not exist';
+    final public const OUTPUT = 'SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT DOCTRINE2_SAVEPOINT_2 does not exist';
 
     /**
      * @throws \Exception
      */
-    public function testBrokenTest()
+    public function testBrokenTest(): never
     {
         throw new \Exception(self::OUTPUT);
     }

--- a/tests/Stub/PHPUnitJSONLogOutput/JSONLogStub.php
+++ b/tests/Stub/PHPUnitJSONLogOutput/JSONLogStub.php
@@ -8,34 +8,34 @@ use Paraunit\Parser\JSON\Log;
 
 class JSONLogStub
 {
-    public const TWO_ERRORS_TWO_FAILURES = '2Errors2Failures';
+    final public const TWO_ERRORS_TWO_FAILURES = '2Errors2Failures';
 
-    public const ALL_GREEN = 'AllGreen';
+    final public const ALL_GREEN = 'AllGreen';
 
-    public const FATAL_ERROR = 'FatalError';
+    final public const FATAL_ERROR = 'FatalError';
 
-    public const SEGFAULT = 'SegFault';
+    final public const SEGFAULT = 'SegFault';
 
-    public const ONE_ERROR = 'SingleError';
+    final public const ONE_ERROR = 'SingleError';
 
-    public const ONE_INCOMPLETE = 'SingleIncomplete';
+    final public const ONE_INCOMPLETE = 'SingleIncomplete';
 
-    public const ONE_RISKY = 'SingleRisky';
+    final public const ONE_RISKY = 'SingleRisky';
 
-    public const ONE_SKIP = 'SingleSkip';
+    final public const ONE_SKIP = 'SingleSkip';
 
-    public const ONE_WARNING = 'SingleWarning';
+    final public const ONE_WARNING = 'SingleWarning';
 
-    public const UNKNOWN = 'Unknown';
+    final public const UNKNOWN = 'Unknown';
 
-    public const PARSE_ERROR = 'ParseError';
+    final public const PARSE_ERROR = 'ParseError';
 
     /**
      * @throws \Exception
      */
     public static function getLogs(string $filename): string
     {
-        return json_decode(self::getCleanOutputFileContent($filename));
+        return json_decode(self::getCleanOutputFileContent($filename), null, 512, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/tests/Stub/PassThenRetryTestStub.php
+++ b/tests/Stub/PassThenRetryTestStub.php
@@ -6,12 +6,12 @@ namespace Tests\Stub;
 
 class PassThenRetryTestStub extends BrokenTestBase implements BrokenTestInterface
 {
-    public function testPass()
+    public function testPass(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testFail()
+    public function testFail(): never
     {
         $this->fail();
     }
@@ -21,7 +21,7 @@ class PassThenRetryTestStub extends BrokenTestBase implements BrokenTestInterfac
         $this->assertTrue(true);
     }
 
-    public function testBrokenTest()
+    public function testBrokenTest(): never
     {
         throw new \Exception(MySQLDeadLockTestStub::OUTPUT);
     }

--- a/tests/Stub/PassThenRetryTestStub.php
+++ b/tests/Stub/PassThenRetryTestStub.php
@@ -16,7 +16,7 @@ class PassThenRetryTestStub extends BrokenTestBase implements BrokenTestInterfac
         $this->fail();
     }
 
-    public function testPass2()
+    public function testPass2(): void
     {
         $this->assertTrue(true);
     }

--- a/tests/Stub/PostgreSQLDeadLockTestStub.php
+++ b/tests/Stub/PostgreSQLDeadLockTestStub.php
@@ -6,12 +6,12 @@ namespace Tests\Stub;
 
 class PostgreSQLDeadLockTestStub extends BrokenTestBase implements BrokenTestInterface
 {
-    public const OUTPUT = 'SQLSTATE[40P01]: Deadlock detected: 7 ERROR:  deadlock detected';
+    final public const OUTPUT = 'SQLSTATE[40P01]: Deadlock detected: 7 ERROR:  deadlock detected';
 
     /**
      * @throws \Exception
      */
-    public function testBrokenTest()
+    public function testBrokenTest(): never
     {
         throw new \Exception(self::OUTPUT);
     }

--- a/tests/Stub/RaisingDeprecationTestStub.php
+++ b/tests/Stub/RaisingDeprecationTestStub.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class RaisingDeprecationTestStub extends TestCase
 {
-    public const DEPRECATION_MESSAGE = 'This "Foo" method is deprecated';
+    final public const DEPRECATION_MESSAGE = 'This "Foo" method is deprecated';
 
     /**
      * @dataProvider multirunDataprovider

--- a/tests/Stub/RaisingNoticeTestStub.php
+++ b/tests/Stub/RaisingNoticeTestStub.php
@@ -11,7 +11,7 @@ class RaisingNoticeTestStub extends TestCase
     /**
      * @dataProvider errorProvider
      */
-    public function testRaise($errorMessage, $errorLevel): never
+    public function testRaise(string $errorMessage, int $errorLevel): never
     {
         trigger_error($errorMessage, $errorLevel);
         $this->fail();

--- a/tests/Stub/RaisingNoticeTestStub.php
+++ b/tests/Stub/RaisingNoticeTestStub.php
@@ -11,7 +11,7 @@ class RaisingNoticeTestStub extends TestCase
     /**
      * @dataProvider errorProvider
      */
-    public function testRaise($errorMessage, $errorLevel)
+    public function testRaise($errorMessage, $errorLevel): never
     {
         trigger_error($errorMessage, $errorLevel);
         $this->fail();
@@ -26,7 +26,7 @@ class RaisingNoticeTestStub extends TestCase
         ];
     }
 
-    public function testVarDump()
+    public function testVarDump(): never
     {
         var_dump('YOU SHOULD NOT SEE THIS -- var_dump');
         $this->fail();

--- a/tests/Stub/SQLiteDeadLockTestStub.php
+++ b/tests/Stub/SQLiteDeadLockTestStub.php
@@ -6,12 +6,12 @@ namespace Tests\Stub;
 
 class SQLiteDeadLockTestStub extends BrokenTestBase implements BrokenTestInterface
 {
-    public const OUTPUT = 'SQLSTATE[HY000]: General error: 5 database is locked (SQL: insert into "wallets" ("name", "user_id", "updated_at", "created_at") values (test_wallet, 1, 2015-11-25 21:07:38, 2015-11-25 21:07:38))';
+    final public const OUTPUT = 'SQLSTATE[HY000]: General error: 5 database is locked (SQL: insert into "wallets" ("name", "user_id", "updated_at", "created_at") values (test_wallet, 1, 2015-11-25 21:07:38, 2015-11-25 21:07:38))';
 
     /**
      * @throws \Exception
      */
-    public function testBrokenTest()
+    public function testBrokenTest(): never
     {
         throw new \Exception(self::OUTPUT);
     }

--- a/tests/Stub/SegFaultTestStub.php
+++ b/tests/Stub/SegFaultTestStub.php
@@ -6,7 +6,7 @@ namespace Tests\Stub;
 
 class SegFaultTestStub extends BrokenTestBase implements BrokenTestInterface
 {
-    public function testBrokenTest()
+    public function testBrokenTest(): never
     {
         exit(139);
     }

--- a/tests/Stub/StubbedParaunitProcess.php
+++ b/tests/Stub/StubbedParaunitProcess.php
@@ -8,17 +8,13 @@ use Paraunit\Process\AbstractParaunitProcess;
 
 class StubbedParaunitProcess extends AbstractParaunitProcess
 {
-    /** @var string */
-    private $output;
+    private ?string $output = null;
 
-    /** @var string */
-    private $errorOutput;
+    private ?string $errorOutput = null;
 
-    /** @var string */
-    private $commandLine;
+    private readonly string $commandLine;
 
-    /** @var int */
-    private $exitCode;
+    private int $exitCode;
 
     /**
      * {@inheritdoc}

--- a/tests/Stub/TestBTestStubSigInt.php
+++ b/tests/Stub/TestBTestStubSigInt.php
@@ -8,5 +8,6 @@ class TestBTestStubSigInt extends BrokenTestBase implements BrokenTestInterface
 {
     public function testBrokenTest(): void
     {
+        // noop
     }
 }

--- a/tests/Stub/TestCTestStubSigInt.php
+++ b/tests/Stub/TestCTestStubSigInt.php
@@ -8,5 +8,6 @@ class TestCTestStubSigInt extends BrokenTestBase implements BrokenTestInterface
 {
     public function testBrokenTest(): void
     {
+        // noop
     }
 }

--- a/tests/Stub/UnformattedOutputStub.php
+++ b/tests/Stub/UnformattedOutputStub.php
@@ -10,11 +10,6 @@ class UnformattedOutputStub extends Output
 {
     private string $buffer = '';
 
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     public function getOutput(): string
     {
         return $this->buffer;

--- a/tests/Stub/UnformattedOutputStub.php
+++ b/tests/Stub/UnformattedOutputStub.php
@@ -8,13 +8,11 @@ use Symfony\Component\Console\Output\Output;
 
 class UnformattedOutputStub extends Output
 {
-    /** @var string */
-    private $buffer;
+    private string $buffer = '';
 
     public function __construct()
     {
         parent::__construct();
-        $this->buffer = '';
     }
 
     public function getOutput(): string

--- a/tests/Unit/Coverage/CoverageMergerTest.php
+++ b/tests/Unit/Coverage/CoverageMergerTest.php
@@ -47,7 +47,7 @@ class CoverageMergerTest extends BaseUnitTestCase
 
         $coverageData1 = $this->createCodeCoverage();
         $coverageData2 = $this->createCodeCoverage();
-        $coverageData2->setTests([__CLASS__]);
+        $coverageData2->setTests([self::class]);
 
         $fetcher = $this->prophesize(CoverageFetcher::class);
         $fetcher->fetch($process1)
@@ -66,6 +66,6 @@ class CoverageMergerTest extends BaseUnitTestCase
         $merger->onProcessParsingCompleted(new ProcessParsingCompleted($process2));
 
         $this->assertSame($coverageData1, $merger->getCoverageData());
-        $this->assertSame([__CLASS__], $merger->getCoverageData()->getTests());
+        $this->assertSame([self::class], $merger->getCoverageData()->getTests());
     }
 }

--- a/tests/Unit/Filter/FilterTest.php
+++ b/tests/Unit/Filter/FilterTest.php
@@ -11,8 +11,7 @@ use Tests\BaseUnitTestCase;
 
 class FilterTest extends BaseUnitTestCase
 {
-    /** @var string|null */
-    private string $absoluteConfigBaseDir = null;
+    private string $absoluteConfigBaseDir;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Filter/FilterTest.php
+++ b/tests/Unit/Filter/FilterTest.php
@@ -12,12 +12,12 @@ use Tests\BaseUnitTestCase;
 class FilterTest extends BaseUnitTestCase
 {
     /** @var string|null */
-    private $absoluteConfigBaseDir;
+    private string $absoluteConfigBaseDir = null;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->absoluteConfigBaseDir = $this->absoluteConfigBaseDir ?? \dirname(__DIR__, 2) . '/Stub/StubbedXMLConfigs' . DIRECTORY_SEPARATOR;
+        $this->absoluteConfigBaseDir ??= \dirname(__DIR__, 2) . '/Stub/StubbedXMLConfigs' . DIRECTORY_SEPARATOR;
     }
 
     public function testFilterTestFilesGetsOnlyRequestedTestsuite(): void

--- a/tests/Unit/Parser/JSON/RiskyParserTest.php
+++ b/tests/Unit/Parser/JSON/RiskyParserTest.php
@@ -26,7 +26,7 @@ class RiskyParserTest extends BaseUnitTestCase
         $resultContainer = $this->prophesize(TestResultContainer::class);
         $methodProphecy = $resultContainer->handleTestResult($process, Argument::allOf(
             Argument::type(TestResultWithMessage::class),
-            Argument::that(fn (TestResultWithMessage $result) => $result->getFailureMessage() === 'Risky message')
+            Argument::that(fn (TestResultWithMessage $result): bool => $result->getFailureMessage() === 'Risky message')
         ));
         $methodProphecy->shouldNotBeCalled();
 

--- a/tests/Unit/Printer/FinalPrinterTest.php
+++ b/tests/Unit/Printer/FinalPrinterTest.php
@@ -18,7 +18,7 @@ class FinalPrinterTest extends BaseUnitTestCase
     public function testOnEngineEndPrintsTheRightCountSummary(): void
     {
         ClockMock::register(Stopwatch::class);
-        ClockMock::register(__CLASS__);
+        ClockMock::register(self::class);
         $output = new UnformattedOutputStub();
         $chunkSize = $this->prophesize(ChunkSize::class);
         $chunkSize->isChunked()
@@ -51,7 +51,7 @@ class FinalPrinterTest extends BaseUnitTestCase
         $printer->onProcessTerminated();
         $printer->onProcessToBeRetried();
         $printer->onProcessTerminated();
-        usleep(60499999);
+        usleep(60_499_999);
         $printer->onEngineEnd();
 
         ClockMock::withClockMock(false);

--- a/tests/Unit/Printer/ProcessPrinterTest.php
+++ b/tests/Unit/Printer/ProcessPrinterTest.php
@@ -60,7 +60,7 @@ class ProcessPrinterTest extends BaseUnitTestCase
         $output = $this->prophesize(Output::class);
         $output->write(Argument::any())
             ->shouldBeCalledTimes($times);
-        $output->writeln(Argument::that(function ($input) {
+        $output->writeln(Argument::that(function ($input): bool {
             $this->assertEquals(6, strlen($input), 'Wrong output: ' . $input);
 
             return true;

--- a/tests/Unit/Process/CommandLineTest.php
+++ b/tests/Unit/Process/CommandLineTest.php
@@ -53,9 +53,7 @@ class CommandLineTest extends BaseUnitTestCase
         $this->assertContains('--opt', $options);
         $this->assertContains('--optVal=value', $options);
 
-        $extensions = array_filter($options, static function (string $a) {
-            return str_starts_with($a, '--extensions');
-        });
+        $extensions = array_filter($options, static fn (string $a) => str_starts_with($a, '--extensions'));
         $this->assertCount(0, $extensions, '--extensions should no longer be used');
     }
 

--- a/tests/Unit/Process/CommandLineTest.php
+++ b/tests/Unit/Process/CommandLineTest.php
@@ -53,7 +53,7 @@ class CommandLineTest extends BaseUnitTestCase
         $this->assertContains('--opt', $options);
         $this->assertContains('--optVal=value', $options);
 
-        $extensions = array_filter($options, static fn (string $a) => str_starts_with($a, '--extensions'));
+        $extensions = array_filter($options, static fn (string $a): bool => str_starts_with($a, '--extensions'));
         $this->assertCount(0, $extensions, '--extensions should no longer be used');
     }
 

--- a/tests/Unit/Process/CommandLineWithCoverageTest.php
+++ b/tests/Unit/Process/CommandLineWithCoverageTest.php
@@ -129,7 +129,7 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
         $this->assertContains('--opt', $options);
         $this->assertContains('--optVal=value', $options);
 
-        $extensions = array_filter($options, static fn (string $a) => str_starts_with($a, '--extensions'));
+        $extensions = array_filter($options, static fn (string $a): bool => str_starts_with($a, '--extensions'));
         $this->assertCount(0, $extensions, '--extensions should no longer be used');
     }
 

--- a/tests/Unit/Process/CommandLineWithCoverageTest.php
+++ b/tests/Unit/Process/CommandLineWithCoverageTest.php
@@ -129,9 +129,7 @@ class CommandLineWithCoverageTest extends BaseUnitTestCase
         $this->assertContains('--opt', $options);
         $this->assertContains('--optVal=value', $options);
 
-        $extensions = array_filter($options, static function (string $a) {
-            return str_starts_with($a, '--extensions');
-        });
+        $extensions = array_filter($options, static fn (string $a) => str_starts_with($a, '--extensions'));
         $this->assertCount(0, $extensions, '--extensions should no longer be used');
     }
 

--- a/tests/Unit/Process/SymfonyProcessWrapperTest.php
+++ b/tests/Unit/Process/SymfonyProcessWrapperTest.php
@@ -27,7 +27,7 @@ class SymfonyProcessWrapperTest extends BaseUnitTestCase
             ->shouldBeCalledTimes(1);
         $process->getEnv()
             ->willReturn([]);
-        $process->setEnv(Argument::that(function ($envVariables) {
+        $process->setEnv(Argument::that(function ($envVariables): bool {
             $this->assertArrayHasKey(EnvVariables::PROCESS_UNIQUE_ID, $envVariables);
             $this->assertArrayHasKey(EnvVariables::PIPELINE_NUMBER, $envVariables);
             $this->assertEquals(4, $envVariables[EnvVariables::PIPELINE_NUMBER]);


### PR DESCRIPTION
Adding Rector is more than needed; adding it to the 2.0 release helps into adopting as much Rector rules as possible and benefit the most from both the major version bump and the requirement for PHP 8.1

TODO:

- [x] add Rector to CI
- [x] apply first run of Rector
- [x] add more rules
- [x] migrate to pure DTOs leveraging `readonly` where possible