### PR TITLE
Upgrade/unlock PHPStan & Rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpspec/prophecy": "dev-master as 1.18",
         "phpspec/prophecy-phpunit": "dev-master as 2.2.0",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "~1.9.18",
+        "phpstan/phpstan": "^1.10.4",
         "phpstan/phpstan-phpunit": "^1.1",
         "phpunit/php-invoker": "^4.0",
         "psalm/plugin-phpunit": "^0.18",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "783226121ed51f55e7ef85db34c3c06d",
+    "content-hash": "621d2bc14087e377bcf80c58be809968",
     "packages": [
         {
             "name": "jean85/pretty-package-versions",
@@ -4415,16 +4415,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.20.3",
+            "version": "1.20.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2"
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6c04009f6cae6eda2f040745b6b846080ef069c2",
-                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
                 "shasum": ""
             },
             "require": {
@@ -4454,22 +4454,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.3"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
             },
-            "time": "2023-04-25T09:01:03+00:00"
+            "time": "2023-05-02T09:19:37+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.18",
+            "version": "1.10.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f2d5cf71be91172a57c649770b73c20ebcffb0bf"
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f2d5cf71be91172a57c649770b73c20ebcffb0bf",
-                "reference": "f2d5cf71be91172a57c649770b73c20ebcffb0bf",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
                 "shasum": ""
             },
             "require": {
@@ -4498,8 +4498,11 @@
                 "static analysis"
             ],
             "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.18"
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
             "funding": [
                 {
@@ -4515,25 +4518,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-17T15:01:27+00:00"
+            "time": "2023-04-19T13:47:27+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "1.3.4",
+            "version": "1.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "d77af96c1aaec28f7c0293677132eaaad079e01b"
+                "reference": "9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d77af96c1aaec28f7c0293677132eaaad079e01b",
-                "reference": "d77af96c1aaec28f7c0293677132eaaad079e01b",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c",
+                "reference": "9e1b9de6d260461f6e99b6a8f2dbb0bbb98b579c",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.9.3"
+                "phpstan/phpstan": "^1.10"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
@@ -4565,9 +4568,9 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.4"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.11"
             },
-            "time": "2023-02-09T08:05:29+00:00"
+            "time": "2023-03-25T19:42:13+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4795,21 +4798,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "0.15.17",
+            "version": "0.15.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "7f6ee7974175138864d3b50c28ea73a7b0fd4e2d"
+                "reference": "015935c7ed9e48a4f5895ba974f337e20a263841"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/7f6ee7974175138864d3b50c28ea73a7b0fd4e2d",
-                "reference": "7f6ee7974175138864d3b50c28ea73a7b0fd4e2d",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/015935c7ed9e48a4f5895ba974f337e20a263841",
+                "reference": "015935c7ed9e48a4f5895ba974f337e20a263841",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.9.14"
+                "phpstan/phpstan": "^1.10.14"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -4836,9 +4839,15 @@
                 "MIT"
             ],
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.15.17"
+                "source": "https://github.com/rectorphp/rector/tree/0.15.25"
             },
             "funding": [
                 {
@@ -4846,7 +4855,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-17T20:34:07+00:00"
+            "time": "2023-04-20T16:07:39+00:00"
         },
         {
             "name": "spatie/array-to-xml",

--- a/src/Configuration/PHPUnitConfig.php
+++ b/src/Configuration/PHPUnitConfig.php
@@ -43,7 +43,7 @@ class PHPUnitConfig
                 continue;
             }
 
-            $class = $extension->attributes?->getNamedItem('class');
+            $class = $extension->attributes->getNamedItem('class');
             if (! $class instanceof \DOMAttr) {
                 continue;
             }

--- a/src/Coverage/CoverageMerger.php
+++ b/src/Coverage/CoverageMerger.php
@@ -50,7 +50,7 @@ class CoverageMerger implements EventSubscriberInterface
 
     public function getCoverageData(): CodeCoverage
     {
-        if ($this->coverageData !== null) {
+        if ($this->coverageData instanceof CodeCoverage) {
             return $this->coverageData;
         }
 

--- a/src/Coverage/Processor/AbstractText.php
+++ b/src/Coverage/Processor/AbstractText.php
@@ -30,7 +30,7 @@ abstract class AbstractText implements CoverageProcessorInterface
     {
         $coverageResults = $this->text->process($codeCoverage, $this->showColors);
 
-        if ($this->targetFile !== null) {
+        if ($this->targetFile instanceof OutputFile) {
             file_put_contents($this->targetFile->getFilePath(), $coverageResults);
         } else {
             $this->output->writeln($coverageResults);

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -151,11 +151,9 @@ class Filter implements TestList
         string $defaultValue = null
     ): string {
         /** @psalm-suppress RedundantCondition */
-        if ($testSuiteNode->attributes !== null) {
-            foreach ($testSuiteNode->attributes as $attrName => $attrNode) {
-                if ($attrName === $nodeName) {
-                    return $attrNode->value;
-                }
+        foreach ($testSuiteNode->attributes as $attrName => $attrNode) {
+            if ($attrName === $nodeName) {
+                return $attrNode->value;
             }
         }
 

--- a/src/Runner/Pipeline.php
+++ b/src/Runner/Pipeline.php
@@ -34,12 +34,12 @@ class Pipeline
 
     public function isFree(): bool
     {
-        return $this->process === null;
+        return ! $this->process instanceof Process;
     }
 
     public function isTerminated(): bool
     {
-        if ($this->process !== null) {
+        if ($this->process instanceof Process) {
             return $this->process->isTerminated();
         }
 
@@ -48,7 +48,7 @@ class Pipeline
 
     public function triggerTermination(): bool
     {
-        if (null === $this->process) {
+        if (! $this->process instanceof Process) {
             return false;
         }
 
@@ -73,7 +73,7 @@ class Pipeline
 
     private function handleProcessTermination(): void
     {
-        if ($this->process !== null) {
+        if ($this->process instanceof Process) {
             $this->dispatcher->dispatch(new ProcessTerminated($this->process));
             $this->process = null;
         }

--- a/src/Runner/PipelineCollection.php
+++ b/src/Runner/PipelineCollection.php
@@ -64,7 +64,7 @@ class PipelineCollection
         $processes = [];
         foreach ($this->pipelines as $pipeline) {
             $process = $pipeline->getProcess();
-            if ($process !== null) {
+            if ($process instanceof Process) {
                 $processes[] = $process;
             }
         }

--- a/src/TestResult/ValueObject/TestIssue.php
+++ b/src/TestResult/ValueObject/TestIssue.php
@@ -35,7 +35,7 @@ enum TestIssue: string implements ComparableTestStatus
 
     public function isMoreImportantThan(?ComparableTestStatus $status): bool
     {
-        if ($status === null) {
+        if (! $status instanceof ComparableTestStatus) {
             return true;
         }
 

--- a/src/TestResult/ValueObject/TestOutcome.php
+++ b/src/TestResult/ValueObject/TestOutcome.php
@@ -47,7 +47,7 @@ enum TestOutcome: string implements ComparableTestStatus
 
     public function isMoreImportantThan(?ComparableTestStatus $status): bool
     {
-        if ($status === null) {
+        if (! $status instanceof ComparableTestStatus) {
             return true;
         }
 

--- a/tests/BaseIntegrationTestCase.php
+++ b/tests/BaseIntegrationTestCase.php
@@ -68,7 +68,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
 
     protected function cleanUpTempDirForThisExecution(): void
     {
-        if ($this->container !== null) {
+        if ($this->container instanceof ContainerBuilder) {
             /** @var TempDirectory $tempDirectory */
             $tempDirectory = $this->getService(TempDirectory::class);
             Cleaner::cleanUpDir($tempDirectory->getTempDirForThisExecution());
@@ -116,7 +116,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
      */
     public function getService(string $serviceName): object
     {
-        if ($this->container === null) {
+        if (! $this->container instanceof ContainerBuilder) {
             throw new \RuntimeException('Container not ready');
         }
 
@@ -130,7 +130,7 @@ abstract class BaseIntegrationTestCase extends BaseTestCase
 
     protected function getParameter(string $parameterName): bool|int|float|string
     {
-        if ($this->container !== null) {
+        if ($this->container instanceof ContainerBuilder) {
             $unitEnum = $this->container->getParameter($parameterName);
             $this->assertIsScalar($unitEnum);
 

--- a/tests/Functional/Command/CoverageCommandTest.php
+++ b/tests/Functional/Command/CoverageCommandTest.php
@@ -164,11 +164,12 @@ class CoverageCommandTest extends BaseTestCase
      */
     private function prepareArguments(array $additionalArguments = []): array
     {
-        return array_merge([
+        return [
             'command' => self::COMMAND_NAME,
             '--configuration' => $this->getConfigForStubs(),
             'stringFilter' => 'green',
-        ], $additionalArguments);
+            ...$additionalArguments,
+        ];
     }
 
     private function isXdebugCoverageDisabled(): bool


### PR DESCRIPTION
PHPStan was previously capped at 1.9.x in b0d92a32b9fc2052db6cb6f58bac915c9eeacfde due to phpstan/phpstan#8983, which is now resolved in PHPStan 1.10.4. This PR requires that version, but to complete we need that the same is done inside Rector.