### PR TITLE
Fix bad result handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
  * ...
 
+## [2.0.1] - 2023-04-28
+## Fixed
+ * Fix handling of second outcome on last test of class (i.e. deprecation emitted after the last test has passed) [#204](https://github.com/facile-it/paraunit/pull/204)
+
 ## [2.0.0] - 2023-03-06
 ### Added
  * Support for PHPUnit 10

--- a/src/Logs/JSON/LogHandler.php
+++ b/src/Logs/JSON/LogHandler.php
@@ -75,7 +75,7 @@ class LogHandler
         }
 
         if ($log->status === LogStatus::LogTerminated) {
-            $this->handleLogEnding($process, $log);
+            $this->handleLogEnding($process);
 
             return;
         }
@@ -88,14 +88,14 @@ class LogHandler
         }
     }
 
-    private function handleLogEnding(Process $process, LogData $log): void
+    private function handleLogEnding(Process $process): void
     {
         if ($process->getExitCode() === 0 && $this->actuallyPreparedTestCount === 0) {
             $this->testResultContainer->addTestResult(new TestResult($this->currentTest, TestOutcome::NoTestExecuted));
         }
 
         if ($this->currentTestOutcome !== null) {
-            $this->testResultContainer->addTestResult(TestResult::from($log));
+            $this->testResultContainer->addTestResult(new TestResult($this->currentTest, $this->currentTestOutcome));
         }
 
         if (

--- a/tests/Unit/Logs/EqualsToken.php
+++ b/tests/Unit/Logs/EqualsToken.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Logs;
+
+use Prophecy\Argument\Token\TokenInterface;
+use Prophecy\Util\StringUtil;
+
+class EqualsToken implements TokenInterface, \Stringable
+{
+    private readonly StringUtil $util;
+
+    private string $string;
+
+    public function __construct(private readonly mixed $value, StringUtil $util = null)
+    {
+        $this->util = $util ?? new StringUtil();
+    }
+
+    /**
+     * Scores 11 if argument matches preset value.
+     */
+    public function scoreArgument($argument): bool|int
+    {
+        return $argument == $this->value ? 11 : false;
+    }
+
+    public function isLast(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns string representation for token.
+     */
+    public function __toString(): string
+    {
+        if (! isset($this->string)) {
+            $this->string = sprintf('equals(%s)', $this->util->stringify($this->value));
+        }
+
+        return $this->string;
+    }
+}


### PR DESCRIPTION
On one of my projects, I discovered an error when a deprecation was emitted after the last test was passed; the handling of the log termination had a bug, and this is the fix.