### PR TITLE
Add `--sort` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
  * ...
 
+## [2.1.0] - 2023-05-03
+ * Add `--sort=random` option to execute test classes in random order
+
 ## [2.0.1] - 2023-04-28
 ## Fixed
  * Fix handling of second outcome on last test of class (i.e. deprecation emitted after the last test has passed) [#204](https://github.com/facile-it/paraunit/pull/204)

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -17,6 +17,7 @@
       <code><![CDATA[$input->getOption('parallel')]]></code>
       <code><![CDATA[$input->getOption('pass-through')]]></code>
       <code><![CDATA[$input->getOption('testsuite')]]></code>
+      <code><![CDATA[$input->getOption('sort')]]></code>
     </MixedArgument>
   </file>
   <file src="src/Coverage/CoverageFetcher.php">

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -35,6 +35,7 @@ class ParallelCommand extends Command
         $this->addOption('logo', null, InputOption::VALUE_NONE, 'Print the Shark logo at the top');
         $this->addOption('pass-through', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Inject options to be passed directly to the underlying PHPUnit processes');
         $this->addOption('testsuite', null, InputOption::VALUE_REQUIRED, 'Only run tests from the specified test suite');
+        $this->addOption('sort', null, InputOption::VALUE_REQUIRED, 'Choose in which order to execute the test classes (values: "random" only for now)');
     }
 
     /**

--- a/src/Configuration/ParallelConfiguration.php
+++ b/src/Configuration/ParallelConfiguration.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Paraunit\Configuration;
 
 use Paraunit\Configuration\DependencyInjection\ParallelContainerDefinition;
+use Paraunit\Filter\Filter;
+use Paraunit\Filter\TestList;
 use Paraunit\Printer\DebugPrinter;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,6 +41,7 @@ class ParallelConfiguration
         $this->containerDefinition->configure($containerBuilder);
         $this->loadCommandLineOptions($containerBuilder, $input);
         $this->tagEventSubscribers($containerBuilder);
+        $this->postProcessConfiguration($containerBuilder);
 
         $this->createPublicAliases($containerBuilder);
         $containerBuilder->compile();
@@ -102,6 +105,25 @@ class ParallelConfiguration
                 sprintf(self::PUBLIC_ALIAS_FORMAT, $serviceName),
                 new Alias($serviceName, true)
             );
+        }
+    }
+
+    private function postProcessConfiguration(ContainerBuilder $container): void
+    {
+        $sortOrder = $container->hasParameter('paraunit.sort_order')
+            ? $container->getParameter('paraunit.sort_order')
+            : null;
+
+        if (is_string($sortOrder)) {
+            if ($sortOrder !== 'random') {
+                throw new \InvalidArgumentException('Unexpected value for --sort option: ' . $sortOrder);
+            }
+
+        // TODO
+        //            $filter->setDecoratedService();
+        //            $container->setAlias(TestList::class, Filter::class);
+        } else {
+            $container->setAlias(TestList::class, Filter::class);
         }
     }
 }

--- a/src/Configuration/ParallelConfiguration.php
+++ b/src/Configuration/ParallelConfiguration.php
@@ -6,6 +6,7 @@ namespace Paraunit\Configuration;
 
 use Paraunit\Configuration\DependencyInjection\ParallelContainerDefinition;
 use Paraunit\Filter\Filter;
+use Paraunit\Filter\RandomizeList;
 use Paraunit\Filter\TestList;
 use Paraunit\Printer\DebugPrinter;
 use Psr\Container\ContainerInterface;
@@ -14,7 +15,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ParallelConfiguration
@@ -74,6 +77,7 @@ class ParallelConfiguration
         $containerBuilder->setParameter('paraunit.string_filter', $input->getArgument('stringFilter'));
         $containerBuilder->setParameter('paraunit.show_logo', $input->getOption('logo'));
         $containerBuilder->setParameter('paraunit.pass_through', $input->getOption('pass-through'));
+        $containerBuilder->setParameter('paraunit.sort_order', $input->getOption('sort'));
 
         if ($input->getOption('debug')) {
             $this->enableDebugMode($containerBuilder);
@@ -119,9 +123,9 @@ class ParallelConfiguration
                 throw new \InvalidArgumentException('Unexpected value for --sort option: ' . $sortOrder);
             }
 
-        // TODO
-        //            $filter->setDecoratedService();
-        //            $container->setAlias(TestList::class, Filter::class);
+            $container->setDefinition(TestList::class, new Definition(RandomizeList::class, [
+                new Reference(Filter::class),
+            ]));
         } else {
             $container->setAlias(TestList::class, Filter::class);
         }

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -8,7 +8,7 @@ use Paraunit\Configuration\PHPUnitConfig;
 use PHPUnit\Util\Xml\Loader;
 use SebastianBergmann\FileIterator\Facade;
 
-class Filter
+class Filter implements TestList
 {
     private readonly Loader $xmlLoader;
 
@@ -23,6 +23,11 @@ class Filter
         /** @psalm-suppress InternalClass */
         $this->xmlLoader = new Loader();
         $this->relativePath = $configFile->getBaseDirectory() . DIRECTORY_SEPARATOR;
+    }
+
+    public function getTests(): array
+    {
+        return $this->filterTestFiles();
     }
 
     /**

--- a/src/Filter/RandomizeList.php
+++ b/src/Filter/RandomizeList.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paraunit\Filter;
+
+class RandomizeList implements TestList
+{
+    public function __construct(private readonly TestList $testList)
+    {
+    }
+
+    public function getTests(): array
+    {
+        $tests = $this->testList->getTests();
+
+        shuffle($tests);
+
+        return $tests;
+    }
+}

--- a/src/Filter/TestList.php
+++ b/src/Filter/TestList.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paraunit\Filter;
+
+interface TestList
+{
+    /**
+     * @return string[] a list of test files to be executed
+     */
+    public function getTests(): array;
+}

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -6,7 +6,7 @@ namespace Paraunit\Runner;
 
 use function function_exists;
 use Paraunit\Configuration\ChunkSize;
-use Paraunit\Filter\Filter;
+use Paraunit\Filter\TestList;
 use Paraunit\Lifecycle\BeforeEngineStart;
 use Paraunit\Lifecycle\EngineEnd;
 use Paraunit\Lifecycle\EngineStart;
@@ -29,7 +29,7 @@ class Runner implements EventSubscriberInterface
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ProcessFactory $processFactory,
-        private readonly Filter $filter,
+        private readonly TestList $testList,
         private readonly PipelineCollection $pipelineCollection,
         private readonly ChunkSize $chunkSize,
         private readonly ChunkFile $chunkFile
@@ -99,7 +99,7 @@ class Runner implements EventSubscriberInterface
 
     private function createProcessQueue(): void
     {
-        foreach ($this->filter->filterTestFiles() as $file) {
+        foreach ($this->testList->getTests() as $file) {
             $this->queuedProcesses->enqueue(
                 $this->processFactory->create($file)
             );
@@ -108,7 +108,7 @@ class Runner implements EventSubscriberInterface
 
     private function createChunkedProcessQueue(): void
     {
-        $files = $this->filter->filterTestFiles();
+        $files = $this->testList->getTests();
         foreach (array_chunk($files, $this->chunkSize->getChunkSize()) as $chunkNumber => $filesChunk) {
             $chunkFileName = $this->chunkFile->createChunkFile($chunkNumber, $filesChunk);
             $this->queuedProcesses->enqueue(

--- a/tests/Functional/Command/ParallelCommandTest.php
+++ b/tests/Functional/Command/ParallelCommandTest.php
@@ -260,4 +260,23 @@ class ParallelCommandTest extends BaseTestCase
         $this->assertStringContainsString(RaisingDeprecationTestStub::DEPRECATION_MESSAGE, $output);
         $this->assertStringContainsString('3x Tests\Stub\RaisingDeprecationTestStub::testDeprecation', $output);
     }
+
+    public function testExecutionWithRandomOrder(): void
+    {
+        $application = new Application();
+        $application->add(new ParallelCommand(new ParallelConfiguration()));
+
+        $command = $application->find('run');
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute([
+            'command' => $command->getName(),
+            '--configuration' => $this->getConfigForStubs(),
+            '--sort' => 'random',
+            'stringFilter' => 'Green',
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertEquals(0, $exitCode);
+        $this->assertStringContainsString('Executed: 1 test classes, 3 tests', $output);
+    }
 }

--- a/tests/Unit/Configuration/CoverageConfigurationTest.php
+++ b/tests/Unit/Configuration/CoverageConfigurationTest.php
@@ -134,6 +134,7 @@ class CoverageConfigurationTest extends BaseUnitTestCase
             'logo',
             'chunk-size',
             'pass-through',
+            'sort',
         ];
 
         foreach ($options as $optionName) {
@@ -199,6 +200,7 @@ class CoverageConfigurationTest extends BaseUnitTestCase
             'php',
             'chunk-size',
             'pass-through',
+            'sort',
         ];
 
         foreach ($options as $optionName) {

--- a/tests/Unit/Filter/RandomizeListTest.php
+++ b/tests/Unit/Filter/RandomizeListTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Filter;
+
+use Paraunit\Filter\RandomizeList;
+use Paraunit\Filter\TestList;
+use Tests\BaseUnitTestCase;
+
+class RandomizeListTest extends BaseUnitTestCase
+{
+    public function testGetList(): void
+    {
+        $baseList = $this->prophesize(TestList::class);
+        $baseList->getTests()
+            ->willReturn($this->mockTestList());
+
+        $randomizeList = new RandomizeList($baseList->reveal());
+
+        $this->assertNotEquals($randomizeList->getTests(), $randomizeList->getTests(), 'Got the same order twice, it is not random!');
+    }
+
+    /**
+     * @return string[]
+     */
+    private function mockTestList(): array
+    {
+        $list = [];
+
+        foreach (range(1, 100) as $i) {
+            $list[] = 'some/stub/test' . $i . '.php';
+        }
+
+        return $list;
+    }
+}

--- a/tests/Unit/Runner/RunnerTest.php
+++ b/tests/Unit/Runner/RunnerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Runner;
 
 use Paraunit\Configuration\ChunkSize;
-use Paraunit\Filter\Filter;
+use Paraunit\Filter\TestList;
 use Paraunit\Lifecycle\BeforeEngineStart;
 use Paraunit\Lifecycle\EngineEnd;
 use Paraunit\Lifecycle\EngineStart;
@@ -26,8 +26,8 @@ class RunnerTest extends BaseUnitTestCase
 {
     public function testRunEmptyTestSuite(): void
     {
-        $filter = $this->prophesize(Filter::class);
-        $filter->filterTestFiles()
+        $testList = $this->prophesize(TestList::class);
+        $testList->getTests()
             ->willReturn([]);
         $pipelineCollection = $this->prophesize(PipelineCollection::class);
         $pipelineCollection->triggerProcessTermination()
@@ -43,7 +43,7 @@ class RunnerTest extends BaseUnitTestCase
         $runner = new Runner(
             $this->mockEventDispatcher(),
             $this->mockProcessFactory(),
-            $filter->reveal(),
+            $testList->reveal(),
             $pipelineCollection->reveal(),
             $this->mockChunkSize(false),
             $chunkFile->reveal()
@@ -54,8 +54,8 @@ class RunnerTest extends BaseUnitTestCase
 
     public function testRunWithSomeGreenTests(): void
     {
-        $filter = $this->prophesize(Filter::class);
-        $filter->filterTestFiles()
+        $testList = $this->prophesize(TestList::class);
+        $testList->getTests()
             ->willReturn([
                 'Test1.php',
                 'Test2.php',
@@ -77,7 +77,7 @@ class RunnerTest extends BaseUnitTestCase
         $runner = new Runner(
             $this->mockEventDispatcher(),
             $this->mockProcessFactory(),
-            $filter->reveal(),
+            $testList->reveal(),
             $pipelineCollection->reveal(),
             $this->mockChunkSize(false),
             $chunkFile->reveal()
@@ -88,8 +88,8 @@ class RunnerTest extends BaseUnitTestCase
 
     public function testRunWithChunkedSomeGreenTests(): void
     {
-        $filter = $this->prophesize(Filter::class);
-        $filter->filterTestFiles()
+        $testList = $this->prophesize(TestList::class);
+        $testList->getTests()
             ->willReturn([
                 'Test1.php',
                 'Test2.php',
@@ -116,7 +116,7 @@ class RunnerTest extends BaseUnitTestCase
         $runner = new Runner(
             $this->mockEventDispatcher(),
             $this->mockProcessFactory('.xml'),
-            $filter->reveal(),
+            $testList->reveal(),
             $pipelineCollection->reveal(),
             $this->mockChunkSize(true),
             $chunkFile->reveal()
@@ -135,8 +135,8 @@ class RunnerTest extends BaseUnitTestCase
         $eventDispatcher->dispatch(Argument::cetera())
             ->shouldNotBeCalled();
 
-        $filter = $this->prophesize(Filter::class);
-        $filter->filterTestFiles()
+        $testList = $this->prophesize(TestList::class);
+        $testList->getTests()
             ->willReturn([]);
         $pipelineCollection = $this->prophesize(PipelineCollection::class);
         $pipelineCollection->push($process)
@@ -149,7 +149,7 @@ class RunnerTest extends BaseUnitTestCase
         $runner = new Runner(
             $eventDispatcher->reveal(),
             $this->mockProcessFactory(),
-            $filter->reveal(),
+            $testList->reveal(),
             $pipelineCollection->reveal(),
             $chunkSize->reveal(),
             $chunkFile->reveal()
@@ -168,8 +168,8 @@ class RunnerTest extends BaseUnitTestCase
         $eventDispatcher->dispatch(Argument::cetera())
             ->shouldNotBeCalled();
 
-        $filter = $this->prophesize(Filter::class);
-        $filter->filterTestFiles()
+        $testList = $this->prophesize(TestList::class);
+        $testList->getTests()
             ->willReturn([]);
         $pipelineCollection = $this->prophesize(PipelineCollection::class);
         $pipelineCollection->push($process)
@@ -182,7 +182,7 @@ class RunnerTest extends BaseUnitTestCase
         $runner = new Runner(
             $eventDispatcher->reveal(),
             $this->mockProcessFactory(),
-            $filter->reveal(),
+            $testList->reveal(),
             $pipelineCollection->reveal(),
             $chunkSize->reveal(),
             $chunkFile->reveal()


### PR DESCRIPTION
I needed to execute tests in random order to even the load on additional services in CI (i.e. a Mongo DB), so this is the first implementation of the `--sort` option. I intentionally avoided using the overlapping name of `--order-by` from PHPUnit because I didn't find a way yet to cleanly hook into that king of behavior (size sorting, defect sorting). I'll see if I'll be able to change that in the future.

This will be in a 2.1 release, while everything else will be pushed into a 2.2.