### PR TITLE
#207 - Adding log-junuit example for v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "symfony/dependency-injection": "^4.4||^5.0||^6.0",
         "symfony/event-dispatcher": "^4.4||^5.0||^6.0",
         "symfony/process": "^4.4||^5.0||^6.0",
-        "symfony/stopwatch": "^4.4||^5.0||^6.0"
+        "symfony/stopwatch": "^4.4||^5.0||^6.0",
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "facile-it/facile-coding-standard": "^0.5.1",

--- a/src/Command/ParallelCommand.php
+++ b/src/Command/ParallelCommand.php
@@ -51,6 +51,7 @@ class ParallelCommand extends Command
             new PHPUnitOption('static-backup', false),
 
             new PHPUnitOption('loader'),
+            new PHPUnitOption('log-junit'),
             new PHPUnitOption('repeat'),
             new PHPUnitOption('printer'),
 

--- a/src/Configuration/DependencyInjection/ParallelContainerDefinition.php
+++ b/src/Configuration/DependencyInjection/ParallelContainerDefinition.php
@@ -26,6 +26,7 @@ use Paraunit\Runner\PipelineCollection;
 use Paraunit\Runner\PipelineFactory;
 use Paraunit\Runner\Runner;
 use Paraunit\TestResult\TestResultList;
+use Paraunit\Util\Log\JUnit\JUnit;
 use Psr\EventDispatcher\EventDispatcherInterface as PsrEventDispatcherInterface;
 use SebastianBergmann\FileIterator\Facade;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -74,6 +75,8 @@ class ParallelContainerDefinition
             '%paraunit.phpunit_config_filename%',
         ]))
             ->setPublic(true);
+        $container->setDefinition(JUnit::class, new Definition(JUnit::class));
+
         $container->setDefinition(TempFilenameFactory::class, new Definition(TempFilenameFactory::class, [
             new Reference(TempDirectory::class),
         ]));
@@ -117,6 +120,7 @@ class ParallelContainerDefinition
             new Reference(TestResultList::class),
             $output,
             new Reference(ChunkSize::class),
+            new Reference(JUnit::class),
         ];
         $container->setDefinition(FinalPrinter::class, new Definition(FinalPrinter::class, $finalPrinterArguments));
         $container->setDefinition(FailuresPrinter::class, new Definition(FailuresPrinter::class, $finalPrinterArguments));
@@ -133,6 +137,7 @@ class ParallelContainerDefinition
         $container->setDefinition(CommandLine::class, new Definition(CommandLine::class, [
             new Reference(PHPUnitBinFile::class),
             new Reference(ChunkSize::class),
+            new Reference(JUnit::class)
         ]));
 
         $container->setDefinition(ProcessFactoryInterface::class, new Definition(ProcessFactory::class, [

--- a/src/Configuration/EnvVariables.php
+++ b/src/Configuration/EnvVariables.php
@@ -11,4 +11,6 @@ class EnvVariables
     public const PIPELINE_NUMBER = 'PARAUNIT_PIPELINE_NUMBER';
 
     public const PROCESS_UNIQUE_ID = 'PARAUNIT_PROCESS_UNIQUE_ID';
+
+    public const LOG_JUNIT_DIR = 'PARAUNIT_LOG_JUNIT_DIR';
 }

--- a/src/Configuration/ParallelConfiguration.php
+++ b/src/Configuration/ParallelConfiguration.php
@@ -76,6 +76,8 @@ class ParallelConfiguration
         $containerBuilder->setParameter('paraunit.testsuite', $input->getOption('testsuite'));
         $containerBuilder->setParameter('paraunit.string_filter', $input->getArgument('stringFilter'));
         $containerBuilder->setParameter('paraunit.show_logo', $input->getOption('logo'));
+        $containerBuilder->setParameter('paraunit.log_junit', $input->getOption('log-junit')
+        );
 
         if ($input->getOption('debug')) {
             $this->enableDebugMode($containerBuilder);

--- a/src/Printer/AbstractFinalPrinter.php
+++ b/src/Printer/AbstractFinalPrinter.php
@@ -6,6 +6,7 @@ namespace Paraunit\Printer;
 
 use Paraunit\Configuration\ChunkSize;
 use Paraunit\TestResult\TestResultList;
+use Paraunit\Util\Log\JUnit\JUnit;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractFinalPrinter extends AbstractPrinter
@@ -16,14 +17,20 @@ abstract class AbstractFinalPrinter extends AbstractPrinter
     /** @var ChunkSize */
     protected $chunkSize;
 
+    /** @var JUnit  */
+    protected $log;
+
+
     public function __construct(
         TestResultList $testResultList,
         OutputInterface $output,
-        ChunkSize $chunkSize
+        ChunkSize $chunkSize,
+        JUnit $log
     ) {
         parent::__construct($output);
         $this->testResultList = $testResultList;
         $this->chunkSize = $chunkSize;
+        $this->log = $log;
     }
 
     abstract public function onEngineEnd(): void;

--- a/src/Printer/FinalPrinter.php
+++ b/src/Printer/FinalPrinter.php
@@ -12,6 +12,7 @@ use Paraunit\Lifecycle\ProcessTerminated;
 use Paraunit\Lifecycle\ProcessToBeRetried;
 use Paraunit\TestResult\Interfaces\TestResultContainerInterface;
 use Paraunit\TestResult\TestResultList;
+use Paraunit\Util\Log\JUnit\JUnit;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -33,9 +34,10 @@ class FinalPrinter extends AbstractFinalPrinter implements EventSubscriberInterf
     public function __construct(
         TestResultList $testResultList,
         OutputInterface $output,
-        ChunkSize $chunkSize
+        ChunkSize $chunkSize,
+        JUnit $log
     ) {
-        parent::__construct($testResultList, $output, $chunkSize);
+        parent::__construct($testResultList, $output, $chunkSize, $log);
 
         $this->stopWatch = new Stopwatch();
         $this->processCompleted = 0;

--- a/src/Util/Log/Helpers/DOMDocumentAttributes.php
+++ b/src/Util/Log/Helpers/DOMDocumentAttributes.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paraunit\Util\Log\Helpers;
+
+class DOMDocumentAttributes
+{
+    public const BASE_SUITE_ATTRIBUTES = [
+        'name' => 'All Suites',
+        'tests' => '0',
+        'assertions' => '0',
+        'errors' => '0',
+        'failures' => '0',
+        'skipped' => '0',
+        'time' => '0',
+     ];
+
+    public function getBaseSuiteAttributes(): array
+    {
+        return self::BASE_SUITE_ATTRIBUTES;
+    }
+}

--- a/src/Util/Log/Interfaces/LogInterface.php
+++ b/src/Util/Log/Interfaces/LogInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Paraunit\Util\Log\Interfaces;
+
+interface LogInterface
+{
+    public function setInputFileName(string $inputFileName): void;
+
+    public function checkIfInitialized(): bool;
+
+    public function generateLogForTest(string $testFilename): string;
+
+    public function getExtension(): string;
+
+    public function setExtension(string $inputFileName): void;
+
+    public function getDirname(): string;
+
+    public function setDirname(string $inputFileName): void;
+
+    public function getBasename(): string;
+
+    public function setBasename(string $inputFileName): void;
+
+    public function generate(): int|string;
+
+    public function getFiles(): array;
+
+    public function getInputFileName(): ?string;
+
+    public function getTempDirectory(): array|string;
+}

--- a/src/Util/Log/JUnit/JUnit.php
+++ b/src/Util/Log/JUnit/JUnit.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Paraunit\Util\Log\JUnit;
+
+use DOMDocument;
+use DOMElement;
+use DOMException;
+use Exception;
+use Paraunit\Util\Log\Helpers\DOMDocumentAttributes;
+use Paraunit\Util\Log\Interfaces\LogInterface;
+use RuntimeException;
+use SimpleXMLElement;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Paraunit\Configuration\EnvVariables;
+
+class JUnit implements LogInterface
+{
+    private const JUNIT_TEMP_DIRECTORY = 'junit_temp_dir';
+    /** @var DOMDocument  */
+    private $document;
+    /** @var DOMDocumentAttributes  */
+    private $documentAttributes;
+    /** @var string  */
+    private $inputFileName;
+    /** @var string  */
+    private $dirname;
+    /** @var string  */
+    private $basename;
+    /** @var string  */
+    private $extension;
+    /** @var array  */
+    private $files = [];
+    /**
+     * @var DOMElement[]
+     */
+    private $domElements = [];
+    private $keysToCalculate = ['assertions', 'time', 'tests', 'errors', 'failures', 'skipped'];
+
+    public function generateLogForTest(string $testFilename): string
+    {
+        return $this->init($this->getInputFileName(), $testFilename);
+    }
+
+    /**
+     * Generates file where the log-junit report for the current $testFilename will be stored
+     * returns CLI command '--log-junit='$file' that will be called from options array.
+     */
+    private function init(string $inputFilename, string $testFilename): string
+    {
+        $this->setDirname($inputFilename);
+        $this->setExtension($inputFilename);
+        $this->setBasename($inputFilename);
+        $this->setDOMDocumentAttributes();
+
+        //Generate file per test
+        $file = $this->getDirname() .
+            DIRECTORY_SEPARATOR .
+            $this->getTempDirectory() .
+            DIRECTORY_SEPARATOR .
+            "{$this->getBasename()}_{$this->getRandomName($testFilename)}.{$this->getExtension()}";
+
+        //Store the generated file in array to merge them later
+        $this->files[] = $file;
+        return '--log-junit=' . $file;
+    }
+
+    public function setDOMDocumentAttributes(): void
+    {
+        $this->documentAttributes = new DOMDocumentAttributes();
+    }
+
+    public function getDirname(): string
+    {
+        return $this->dirname;
+    }
+
+    public function setDirname(string $inputFileName): void
+    {
+        $this->dirname = dirname($inputFileName);
+    }
+
+    public function getTempDirectory(): array|string
+    {
+        $junitTempDir = getenv(EnvVariables::LOG_JUNIT_DIR);
+
+        if ($junitTempDir === false) {
+            return self::JUNIT_TEMP_DIRECTORY;
+        }
+
+        if (substr($junitTempDir, -1) !== DIRECTORY_SEPARATOR) {
+            $junitTempDir .= DIRECTORY_SEPARATOR;
+        }
+
+        return $junitTempDir;
+    }
+
+    public function getBasename(): string
+    {
+        return $this->basename;
+    }
+
+    public function setBasename(string $inputFileName): void
+    {
+        $basename = basename($inputFileName, ".{$this->getExtension()}");
+        $this->basename = $basename;
+    }
+
+    private function getRandomName(string $testFilename): string
+    {
+        return md5($testFilename);
+    }
+
+    public function getExtension(): string
+    {
+        return $this->extension;
+    }
+
+    public function setExtension(string $inputFileName): void
+    {
+        $this->extension = pathinfo($inputFileName, PATHINFO_EXTENSION) !== ''
+            ? pathinfo($inputFileName, PATHINFO_EXTENSION)
+            : 'xml';
+    }
+
+    public function getInputFileName(): ?string
+    {
+        return $this->inputFileName ?? null;
+    }
+
+    public function setInputFileName(string $inputFileName): void
+    {
+        $this->inputFileName = $this->checkInputFileNameExtension($inputFileName);
+    }
+
+    private function checkInputFileNameExtension(string $inputFileName): string
+    {
+        return pathinfo($inputFileName, PATHINFO_EXTENSION) !== ''
+            ? $inputFileName
+            : $inputFileName . '.' . 'xml';
+    }
+
+    public function getFiles(): array
+    {
+        return $this->files;
+    }
+
+    public function checkIfInitialized(): bool
+    {
+        if (!isset($this->inputFileName)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @throws DOMException
+     */
+    public function generate(): int|string
+    {
+        $finder = new Finder();
+        $finder->files()
+            ->name($this->getBasename() . '*')
+            ->in(realpath($this->getTempDirectory()));
+
+        $this->document = new DOMDocument('1.0', 'UTF-8');
+        $this->document->formatOutput = true;
+
+        $root = $this->document->createElement('testsuites');
+        $baseSuite = $this->document->createElement('testsuite');
+
+        foreach ($this->documentAttributes->getBaseSuiteAttributes() as $qualifiedName => $value) {
+            $baseSuite->setAttribute($qualifiedName, $value);
+        }
+
+        $this->domElements['All Suites'] = $baseSuite;
+
+        $root->appendChild($baseSuite);
+        $this->document->appendChild($root);
+
+        foreach ($finder as $file) {
+            try {
+                $xml = new SimpleXMLElement(file_get_contents($file->getRealPath()));
+                $xmlArray = json_decode(json_encode($xml, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+                if (!empty($xmlArray)) {
+                    $this->addTestSuites($baseSuite, $xmlArray);
+                }
+            } catch (Exception $exception) {
+                return $exception->getMessage();
+//                $output->writeln(sprintf('<error>Error in file %s: %s</error>', $file->getRealPath(), $exception->getMessage()));
+            }
+        }
+
+        foreach ($this->domElements as $domElement) {
+            if ($domElement->hasAttribute('parent')) {
+                $domElement->removeAttribute('parent');
+            }
+        }
+
+        $this->calculateTopLevelStats();
+        $file = $this->getInputFileName();
+        if (!is_dir(dirname($file)) && !mkdir($concurrentDirectory = dirname($file), 0777, true) && !is_dir(
+                $concurrentDirectory
+            )) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
+        }
+
+        $this->document->save($this->getInputFileName());
+
+        //Cleanup temp directory
+        $this->deleteTempFiles();
+
+        return 0;
+    }
+
+    private function addTestSuites(DOMElement $parent, array $testSuites): void
+    {
+        foreach ($testSuites as $testSuite) {
+            if (empty($testSuite['@attributes']['name'])) {
+                if (!empty($testSuite['testsuite'])) {
+                    $this->addTestSuites($parent, $testSuite);
+                }
+                continue;
+            }
+            $name = $testSuite['@attributes']['name'];
+
+            if (isset($this->domElements[$name])) {
+                $element = $this->domElements[$name];
+            } else {
+                $element = $this->document->createElement('testsuite');
+                $element->setAttribute('parent', $parent->getAttribute('name'));
+                $attributes = $testSuite['@attributes'] ?? [];
+                foreach ($attributes as $key => $value) {
+                    $element->setAttribute($key, (string)$value);
+                }
+                $parent->appendChild($element);
+                $this->domElements[$name] = $element;
+            }
+
+            if (!empty($testSuite['testsuite'])) {
+                $children = isset($testSuite['testsuite']['@attributes']) ? [$testSuite['testsuite']] : $testSuite['testsuite'];
+                $this->addTestSuites($element, $children);
+            }
+
+            if (!empty($testSuite['testcase'])) {
+                $children = isset($testSuite['testcase']['@attributes']) ? [$testSuite['testcase']] : $testSuite['testcase'];
+                $this->addTestCases($element, $children);
+            }
+        }
+    }
+
+    private function addTestCases(DOMElement $parent, array $testCases): void
+    {
+        foreach ($testCases as $testCase) {
+            $attributes = $testCase['@attributes'] ?? [];
+            if (empty($testCase['@attributes']['name'])) {
+                continue;
+            }
+            $name = $testCase['@attributes']['name'];
+
+            $element = $this->document->createElement('testcase');
+            foreach ($attributes as $key => $value) {
+                $element->setAttribute($key, (string)$value);
+            }
+            if (isset($testCase['failure']) || isset($testCase['warning']) || isset($testCase['error'])) {
+                $this->addChildElements($testCase, $element);
+            }
+            $parent->appendChild($element);
+            $this->domElements[$name] = $element;
+        }
+    }
+
+    private function addChildElements(array $tree, DOMElement $element): void
+    {
+        foreach ($tree as $key => $value) {
+            if ($key === '@attributes') {
+                continue;
+            }
+            $child = $this->document->createElement($key);
+            $child->nodeValue = $value;
+            $element->appendChild($child);
+        }
+    }
+
+    private function calculateTopLevelStats(): void
+    {
+        /** @var DOMElement $topNode */
+        $suites = $this->document->getElementsByTagName('testsuites')->item(0);
+        $topNode = $suites->firstChild;
+        if ($topNode->hasChildNodes()) {
+            $stats = array_flip($this->keysToCalculate);
+            $stats = array_map(function ($_value) {
+                return 0;
+            }, $stats);
+            foreach ($topNode->childNodes as $child) {
+                $attributes = $child->attributes;
+                foreach ($attributes as $key => $value) {
+                    if (in_array($key, $this->keysToCalculate, true)) {
+                        $stats[$key] += $value->nodeValue;
+                    }
+                }
+            }
+
+            foreach ($stats as $key => $value) {
+                $topNode->setAttribute($key, (string)$value);
+            }
+        }
+    }
+
+    private function deleteTempFiles(): void
+    {
+        $filesystem = new Filesystem();
+        $filesystem->remove(realpath($this->getTempDirectory()));
+    }
+}

--- a/tests/Unit/Process/CommandLineTest.php
+++ b/tests/Unit/Process/CommandLineTest.php
@@ -10,6 +10,7 @@ use Paraunit\Configuration\PHPUnitConfig;
 use Paraunit\Configuration\PHPUnitOption;
 use Paraunit\Parser\JSON\TestHook as Hooks;
 use Paraunit\Process\CommandLine;
+use Paraunit\Util\Log\JUnit\JUnit;
 use Tests\BaseUnitTestCase;
 
 class CommandLineTest extends BaseUnitTestCase


### PR DESCRIPTION
Hi @Jean85 , I am adding this MR to provide some idea how I have solved the log-junit  in paraunit.
This was one of the main features that i needed in the rewrite i mentioned to you via email.
I did not had a chance to go over the 2.x version knowing you made a huge refactor but I will get to it in my free time.

The basic idea is to send the log-junit command to each of the processes i.e either chunks or tests and generate files based on the filename provided -> --log-unit=test.xml and the output will be stored in the junit dir then merged into one file and the directory will be deleted something similar to what you are doing with the chunks currently.
