### PR TITLE
feat: allow PHPUnit 11

### DIFF
--- a/.github/workflows/phpunit_11_special.sh
+++ b/.github/workflows/phpunit_11_special.sh
@@ -16,5 +16,10 @@ composer update
 rm -fr tmp
 mkdir tmp
 echo '{}' > tmp/composer.json
-composer require --working-dir=tmp 'phpspec/prophecy-phpunit:dev-master'
+composer require --dev --no-update --working-dir=tmp 'phpspec/prophecy-phpunit:dev-master'
+composer require --dev --no-update --working-dir=tmp 'sebastian/comparator:5.0.1 as 6.0.0'
+composer require --dev --no-update --working-dir=tmp 'sebastian/diff:5.1.0 as 6.0.0'
+composer require --dev --no-update --working-dir=tmp 'phpunit/phpunit:11.0.1 as 10.1.0' -W
+composer require --dev --no-update --working-dir=tmp 'sebastian/exporter:5.1.1 as 6.0.0'
+composer require --dev --working-dir=tmp 'sebastian/recursion-context:5.0.0 as 6.0.0'
 sed -i 's~"vendor/autoload.php"~"tmp/vendor/autoload.php"~g' phpunit.xml.dist

--- a/.github/workflows/phpunit_11_special.sh
+++ b/.github/workflows/phpunit_11_special.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+composer remove --dev --no-update facile-it/facile-coding-standard
+composer remove --dev --no-update phpspec/prophecy-phpunit
+composer remove --dev --no-update psalm/plugin-phpunit
+composer remove --dev --no-update psalm/plugin-symfony
+composer remove --dev --no-update vimeo/psalm
+composer require --dev --no-update 'phpunit/php-invoker:^4.0||^5.0'
+composer require --dev --no-update 'sebastian/comparator:5.0.1 as 6.0.0'
+composer require --dev --no-update 'sebastian/diff:5.1.0 as 6.0.0'
+composer require --dev --no-update 'sebastian/exporter:5.1.1 as 6.0.0'
+composer require --dev --no-update 'sebastian/recursion-context:5.0.0 as 6.0.0'
+composer update
+
+rm -fr tmp
+mkdir tmp
+echo '{}' > tmp/composer.json
+composer require --working-dir=tmp 'phpspec/prophecy-phpunit:dev-master'
+sed -i 's~"vendor/autoload.php"~"tmp/vendor/autoload.php"~g' phpunit.xml.dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,10 @@ jobs:
             coverage: 'xdebug2'
             php: '8.1'
             dependencies: 'lowest'
+          - description: 'PHPUnit 11 special'
+            coverage: 'none'
+            php: '8.3'
+            phpunit_11_special: 'yes'
 
     name: PHP ${{ matrix.php }} ${{ matrix.description }}
     steps:
@@ -41,8 +45,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: ${{ matrix.coverage }}
-        # @TODO: remove line below when vimeo/psalm allow nikic/php-parser:^5
-      - run: composer remove --dev vimeo/psalm --no-update
+      - run: ./.github/workflows/phpunit_11_special.sh
+        if: matrix.phpunit_11_special == 'yes'
       - run: composer remove --dev facile-it/facile-coding-standard --no-update
         if: matrix.dependencies == 'lowest'
       - uses: ramsey/composer-install@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
   Tests:
     runs-on: 'ubuntu-latest'
     env:
-      SYMFONY_DEPRECATIONS_HELPER: disabled      
+      SYMFONY_DEPRECATIONS_HELPER: disabled
     strategy:
       matrix:
         php:
@@ -41,6 +41,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: ${{ matrix.coverage }}
+        # @TODO: remove line below when vimeo/psalm allow nikic/php-parser:^5
+      - run: composer remove --dev vimeo/psalm --no-update
       - run: composer remove --dev facile-it/facile-coding-standard --no-update
         if: matrix.dependencies == 'lowest'
       - uses: ramsey/composer-install@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,6 +52,7 @@ jobs:
       - uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
+      - run: vendor/bin/phpunit --version
       - run: vendor/bin/phpunit --coverage-clover=coverage.xml --colors=always
       - uses: codecov/codecov-action@v3
         with:

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "jean85/pretty-package-versions": "^1.5.1||^2.0.1",
-        "phpunit/php-code-coverage": "^10.0",
+        "phpunit/php-code-coverage": "^10.0||^11.0",
         "phpunit/php-file-iterator": "^4.0",
         "phpunit/phpunit": "^10.5.4||^11.0",
         "psr/event-dispatcher": "^1.0",
@@ -85,5 +85,9 @@
     "suggest": {
         "ext-pcov": "A coverage driver for faster collection",
         "dama/doctrine-test-bundle": "Useful for Symfony+Doctrine functional testing, providing DB isolation"
+    },
+    "scripts": {
+        "cs-check": "php-cs-fixer fix --dry-run --diff",
+        "cs-fix": "php-cs-fixer fix --diff"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-json": "*",
         "jean85/pretty-package-versions": "^1.5.1||^2.0.1",
         "phpunit/php-code-coverage": "^10.0||^11.0",
-        "phpunit/php-file-iterator": "^4.0",
+        "phpunit/php-file-iterator": "^4.0||^5.0",
         "phpunit/phpunit": "^10.5.4||^11.0",
         "psr/event-dispatcher": "^1.0",
         "symfony/console": "^4.4||^5.0||^6.0||^7.0",


### PR DESCRIPTION
PHPUnit 11 requires `phpunit/php-code-coverage:^11.0`: https://github.com/sebastianbergmann/phpunit/blob/11.0.0/composer.json#L35

CI changes are made because:
- `phpunit/php-code-coverage:^11.0` [requires](https://github.com/sebastianbergmann/php-code-coverage/blob/11.0.0/composer.json#L36) `nikic/php-parser:^5.0`
- the latest stable `vimeo/psalm` [does not yet allow](https://github.com/vimeo/psalm/blob/v4.25.0/composer.json#L34)  `nikic/php-parser:^5.0`.