### PR TITLE
Fix recap printers

### DIFF
--- a/tests/Functional/Printer/FilesRecapPrinterTest.php
+++ b/tests/Functional/Printer/FilesRecapPrinterTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Tests\Functional\Printer;
 
 use Paraunit\Printer\FilesRecapPrinter;
+use Paraunit\Runner\Runner;
 use Tests\BaseFunctionalTestCase;
+use Tests\Stub\PassThenRetryTestStub;
 
 class FilesRecapPrinterTest extends BaseFunctionalTestCase
 {
@@ -35,6 +37,29 @@ class FilesRecapPrinterTest extends BaseFunctionalTestCase
             'files with NO TESTS EXECUTED',
             'files with RISKY',
             'files with RETRIED',
+        ]);
+    }
+
+    public function testRegressionDuplicateFilesDueToMethodNames(): void
+    {
+        $this->setTextFilter('PassThenRetryTestStub.php');
+        $this->loadContainer();
+
+        $output = $this->getConsoleOutput();
+        $runner = $this->getService(Runner::class);
+        $this->assertInstanceOf(Runner::class, $runner);
+        $this->assertNotEquals(0, $runner->run());
+
+        $this->assertOutputOrder($output, [
+            'Errors output',
+            PassThenRetryTestStub::class . '::testBrokenTest',
+            PassThenRetryTestStub::class . '::testFail',
+            'files with ERRORS',
+            PassThenRetryTestStub::class . PHP_EOL,
+            'files with FAILURES',
+            PassThenRetryTestStub::class . PHP_EOL,
+            'files with RETRIED',
+            PassThenRetryTestStub::class . PHP_EOL,
         ]);
     }
 }

--- a/tests/Functional/Runner/ChunkFileTest.php
+++ b/tests/Functional/Runner/ChunkFileTest.php
@@ -44,7 +44,7 @@ class ChunkFileTest extends BaseIntegrationTestCase
             'Deprecations output:',
             '3 chunks with ABNORMAL TERMINATIONS (FATAL ERRORS, SEGFAULTS):',
             '8 chunks with ERRORS:',
-            '3 chunks with FAILURES:',
+            '1 chunks with FAILURES:',
             '2 chunks with WARNINGS:',
             '1 chunks with DEPRECATIONS:',
             '5 chunks with RETRIED:',

--- a/tests/Unit/Logs/TestHook/AbstractTestHookTestCase.php
+++ b/tests/Unit/Logs/TestHook/AbstractTestHookTestCase.php
@@ -9,6 +9,7 @@ use Paraunit\Logs\TestHook\AbstractTestHook;
 use Paraunit\Logs\ValueObject\LogData;
 use Paraunit\Logs\ValueObject\LogStatus;
 use Paraunit\Logs\ValueObject\Test;
+use Paraunit\Logs\ValueObject\TestMethod;
 use PHPUnit\Event\Event;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -72,7 +73,7 @@ abstract class AbstractTestHookTestCase extends BaseUnitTestCase
         $this->assertEquals($this->getExpectedStatus(), $logData[0]->status);
 
         if ($this->updatesLastTest()) {
-            $this->assertEquals(new Test(static::class . '::testNotify'), $logData[0]->test);
+            $this->assertEquals($this->getExpectedTestObject(), $logData[0]->test);
         } else {
             $this->assertEquals(Test::unknown(), $logData[0]->test);
         }
@@ -153,5 +154,10 @@ abstract class AbstractTestHookTestCase extends BaseUnitTestCase
         }
 
         return $factory->status();
+    }
+
+    protected function getExpectedTestObject(): Test
+    {
+        return new TestMethod(static::class, 'testNotify');
     }
 }

--- a/tests/Unit/Logs/TestHook/ExecutionStartedTest.php
+++ b/tests/Unit/Logs/TestHook/ExecutionStartedTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Logs\TestHook;
 
 use Paraunit\Logs\TestHook\ExecutionStarted;
 use Paraunit\Logs\ValueObject\LogStatus;
+use Paraunit\Logs\ValueObject\Test;
 use PHPUnit\Event\Code\TestCollection;
 use PHPUnit\Event\TestRunner\ExecutionStarted as TestSuiteExecutionStarted;
 use PHPUnit\Event\TestSuite\TestSuiteForTestClass;
@@ -27,13 +28,15 @@ class ExecutionStartedTest extends AbstractTestHookTestCase
 
     protected function createEvent(): TestSuiteExecutionStarted
     {
-        /** @var class-string $name */
-        $name = self::class . '::testNotify';
-
         return new TestSuiteExecutionStarted(
             $this->createTelemetryInfo(),
-            new TestSuiteForTestClass($name, 0, TestCollection::fromArray([]), __FILE__, 0),
+            new TestSuiteForTestClass(self::class, 0, TestCollection::fromArray([]), __FILE__, 0),
         );
+    }
+
+    protected function getExpectedTestObject(): Test
+    {
+        return new Test(static::class);
     }
 
     protected function getExpectedMessage(): ?string

--- a/tests/Unit/Logs/ValueObject/LogDataTest.php
+++ b/tests/Unit/Logs/ValueObject/LogDataTest.php
@@ -45,7 +45,7 @@ class LogDataTest extends TestCase
         $this->assertSame(self::class . '::testMethod', $logData->test->name);
     }
 
-    public function testSerialization(): void
+    public function testSerializationWithSimpleTest(): void
     {
         $logData = new LogData(LogStatus::Passed, new Test('Foo'), 'Test message');
 
@@ -55,6 +55,22 @@ class LogDataTest extends TestCase
         $this->assertInstanceOf(LogData::class, $parsedResult[0]);
         $this->assertEquals($logData, $parsedResult[0]);
         $this->assertSame('Foo', $parsedResult[0]->test->name);
+    }
+
+    public function testSerializationWithTestMethod(): void
+    {
+        $logData = new LogData(LogStatus::Passed, new TestMethod('Foo', 'bar'), 'Test message');
+
+        $parsedResult = LogData::parse(json_encode($logData, JSON_THROW_ON_ERROR));
+
+        $this->assertCount(2, $parsedResult);
+        $this->assertInstanceOf(LogData::class, $parsedResult[0]);
+        $this->assertEquals($logData, $parsedResult[0]);
+        $this->assertObjectHasProperty('className', $parsedResult[0]->test);
+        $this->assertObjectHasProperty('methodName', $parsedResult[0]->test);
+        $this->assertSame('Foo', $parsedResult[0]->test->className);
+        $this->assertSame('bar', $parsedResult[0]->test->methodName);
+        $this->assertSame('Foo::bar', $parsedResult[0]->test->name);
     }
 
     public function testSerializationError(): void


### PR DESCRIPTION
I noticed that, since Paraunit 2, the recap at the end of the execution got very long. This was due to an improper serialization of the logs, where the test name was treated as a generic `Test` VO instead of a specific `TestMethod`, where the class name is split form the method name.

This had the unintended consequence of not deduplicating the list of files, so in case an error or failure was repeated many times (i.e. with a data provider) inside the same test class, the test recap would get very long.

This fixes it, and reduces the recap verbosity.