### PR TITLE
Add support for Symfony 8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,6 +53,7 @@ jobs:
             dependencies: 'lowest'
           - description: 'Symfony 8'
             php: '8.4'
+            composer-minimum-stability: 'beta'
             composer_options: '--ignore-platform-req=php+'
             symfony-version: '^8.0.0-BETA-1'
 
@@ -66,6 +67,9 @@ jobs:
           ini-values: display_errors=On, display_startup_errors=On, error_reporting=-1, zend.assertions=1
           tools: flex
       - run: composer remove --dev facile-it/facile-coding-standard vimeo/psalm psalm/plugin-phpunit psalm/plugin-symfony --no-update
+      - name: Configure Composer minimum-stability
+        if: matrix.composer-minimum-stability
+        run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
       - run: composer require phpunit/phpunit ${{ matrix.phpunit }} --no-update
         if: matrix.phpunit
       - uses: ramsey/composer-install@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,9 +54,7 @@ jobs:
           - description: 'Symfony 8'
             php: '8.4'
             composer_options: '--ignore-platform-req=php+'
-            dependencies: highest
-            minimum-stability: dev
-            symfony-version: '8.0.x-dev'
+            symfony-version: '^8.0.0-BETA-1'
 
     name: PHP ${{ matrix.php }} ${{ matrix.description }}
     steps:
@@ -66,16 +64,8 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: ${{ matrix.coverage }}
           ini-values: display_errors=On, display_startup_errors=On, error_reporting=-1, zend.assertions=1
-      - name: Configure Composer minimum-stability
-        if: matrix.composer-minimum-stability
-        run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
-      - name: Install Symfony Flex
-        if: matrix.symfony-version
-        run: |
-            composer global config --no-plugins allow-plugins.symfony/flex true
-            composer global require --no-progress --no-scripts --no-plugins symfony/flex
+          tools: flex
       - run: composer remove --dev facile-it/facile-coding-standard vimeo/psalm psalm/plugin-phpunit psalm/plugin-symfony --no-update
-        if: matrix.dependencies == 'lowest' || matrix.phpunit
       - run: composer require phpunit/phpunit ${{ matrix.phpunit }} --no-update
         if: matrix.phpunit
       - uses: ramsey/composer-install@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,13 +12,13 @@ on:
 permissions:
   repository-projects: read
 env:
-  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'  
+  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
 
 jobs:
   Tests:
     runs-on: 'ubuntu-latest'
     env:
-      SYMFONY_DEPRECATIONS_HELPER: disabled      
+      SYMFONY_DEPRECATIONS_HELPER: disabled
     strategy:
       matrix:
         php:
@@ -51,6 +51,12 @@ jobs:
             coverage: 'xdebug2'
             php: '8.1'
             dependencies: 'lowest'
+          - description: 'Symfony 8'
+            php: '8.4'
+            composer_options: '--ignore-platform-req=php+'
+            dependencies: highest
+            minimum-stability: dev
+            symfony-version: '8.0.x-dev'
 
     name: PHP ${{ matrix.php }} ${{ matrix.description }}
     steps:
@@ -60,6 +66,14 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: ${{ matrix.coverage }}
           ini-values: display_errors=On, display_startup_errors=On, error_reporting=-1, zend.assertions=1
+      - name: Configure Composer minimum-stability
+        if: matrix.composer-minimum-stability
+        run: composer config minimum-stability ${{ matrix.composer-minimum-stability }}
+      - name: Install Symfony Flex
+        if: matrix.symfony-version
+        run: |
+            composer global config --no-plugins allow-plugins.symfony/flex true
+            composer global require --no-progress --no-scripts --no-plugins symfony/flex
       - run: composer remove --dev facile-it/facile-coding-standard vimeo/psalm psalm/plugin-phpunit psalm/plugin-symfony --no-update
         if: matrix.dependencies == 'lowest' || matrix.phpunit
       - run: composer require phpunit/phpunit ${{ matrix.phpunit }} --no-update
@@ -68,6 +82,8 @@ jobs:
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: ${{ matrix.composer_options }}
+        env:
+          SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
       - run: vendor/bin/phpunit --check-php-configuration
         if: matrix.dependencies != 'lowest'
       - run: vendor/bin/phpunit --coverage-clover=coverage.xml --colors=always

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,11 @@
         "phpunit/php-file-iterator": "^4.0||^5.0||^6.0",
         "phpunit/phpunit": "^10.5.4||^11.0||^12.0",
         "psr/event-dispatcher": "^1.0",
-        "symfony/console": "^4.4||^5.0||^6.0||^7.0",
-        "symfony/dependency-injection": "^4.4||^5.0||^6.0||^7.0",
-        "symfony/event-dispatcher": "^4.4||^5.0||^6.0||^7.0",
-        "symfony/process": "^4.4||^5.0||^6.0||^7.0",
-        "symfony/stopwatch": "^4.4||^5.0||^6.0||^7.0"
+        "symfony/console": "^4.4||^5.0||^6.0||^7.0||^8.0",
+        "symfony/dependency-injection": "^4.4||^5.0||^6.0||^7.0||^8.0",
+        "symfony/event-dispatcher": "^4.4||^5.0||^6.0||^7.0||^8.0",
+        "symfony/process": "^4.4||^5.0||^6.0||^7.0||^8.0",
+        "symfony/stopwatch": "^4.4||^5.0||^6.0||^7.0||^8.0"
     },
     "require-dev": {
         "facile-it/facile-coding-standard": "^1.0",
@@ -49,8 +49,8 @@
         "psalm/plugin-phpunit": "^0.19",
         "psalm/plugin-symfony": "^5.0",
         "rector/rector": "2.2.7",
-        "symfony/expression-language": "^4.4||^5.0||^6.0||^7.0",
-        "symfony/phpunit-bridge": "^6.4||^7.0",
+        "symfony/expression-language": "^4.4||^5.0||^6.0||^7.0||^8.0",
+        "symfony/phpunit-bridge": "^6.4||^7.0||^8.0",
         "vimeo/psalm": "^5.5.0||^6.0"
     },
     "conflict": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,8 @@
          cacheResult="false" 
          colors="true"
          bootstrap="vendor/autoload.php"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          failOnWarning="true"
          failOnRisky="true"

--- a/src/Bin/Paraunit.php
+++ b/src/Bin/Paraunit.php
@@ -18,10 +18,8 @@ class Paraunit
         $application = new Application('Paraunit', self::getVersion());
 
         $parallelCommand = new ParallelCommand(new ParallelConfiguration());
-        $application->add($parallelCommand);
-
         $coverageCommand = new CoverageCommand(new CoverageConfiguration());
-        $application->add($coverageCommand);
+        $application->addCommands([$parallelCommand, $coverageCommand]);
 
         return $application;
     }

--- a/tests/Functional/Command/CoverageCommandTest.php
+++ b/tests/Functional/Command/CoverageCommandTest.php
@@ -149,7 +149,7 @@ class CoverageCommandTest extends BaseTestCase
     private function createCommandTester(): CommandTester
     {
         $application = new Application();
-        $application->add(new CoverageCommand(new CoverageConfiguration()));
+        $application->addCommand([new CoverageCommand(new CoverageConfiguration())]);
 
         $command = $application->find(self::COMMAND_NAME);
 

--- a/tests/Functional/Command/CoverageCommandTest.php
+++ b/tests/Functional/Command/CoverageCommandTest.php
@@ -149,7 +149,7 @@ class CoverageCommandTest extends BaseTestCase
     private function createCommandTester(): CommandTester
     {
         $application = new Application();
-        $application->addCommand([new CoverageCommand(new CoverageConfiguration())]);
+        $application->addCommands([new CoverageCommand(new CoverageConfiguration())]);
 
         $command = $application->find(self::COMMAND_NAME);
 

--- a/tests/Functional/Command/ParallelCommandTest.php
+++ b/tests/Functional/Command/ParallelCommandTest.php
@@ -22,7 +22,7 @@ class ParallelCommandTest extends BaseTestCase
     public function testExecutionFailsWithoutExtension(): void
     {
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -44,7 +44,7 @@ class ParallelCommandTest extends BaseTestCase
         $this->assertFalse($configChecker->isParaunitExtensionRegistered());
 
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -65,7 +65,7 @@ class ParallelCommandTest extends BaseTestCase
     {
         $configurationPath = $this->getConfigForStubs();
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -86,7 +86,7 @@ class ParallelCommandTest extends BaseTestCase
     {
         $configurationPath = $this->getConfigForStubs();
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -113,7 +113,7 @@ class ParallelCommandTest extends BaseTestCase
     public function testExecutionWithWarning(): void
     {
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -140,7 +140,7 @@ class ParallelCommandTest extends BaseTestCase
     {
         $configurationPath = $this->getConfigForStubs();
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -159,7 +159,7 @@ class ParallelCommandTest extends BaseTestCase
     {
         $configurationPath = $this->getConfigForStubs();
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -176,7 +176,7 @@ class ParallelCommandTest extends BaseTestCase
     public function testExecutionWithChunksAndTestsuiteOption(): void
     {
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -198,7 +198,7 @@ class ParallelCommandTest extends BaseTestCase
     {
         $configurationPath = $this->getConfigForStubs();
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -229,7 +229,7 @@ class ParallelCommandTest extends BaseTestCase
     {
         $configurationPath = $this->getConfigForStubs();
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -246,7 +246,7 @@ class ParallelCommandTest extends BaseTestCase
     public function testExecutionWithoutConfiguration(): void
     {
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -265,7 +265,7 @@ class ParallelCommandTest extends BaseTestCase
     public function testExecutionWithDeprecationHidden(): void
     {
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -285,7 +285,7 @@ class ParallelCommandTest extends BaseTestCase
     public function testExecutionWithDeprecationListener(): void
     {
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -305,7 +305,7 @@ class ParallelCommandTest extends BaseTestCase
     public function testExecutionWithRandomOrder(): void
     {
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
@@ -324,7 +324,7 @@ class ParallelCommandTest extends BaseTestCase
     public function testRegressionWithPHPUnitError(): void
     {
         $application = new Application();
-        $application->add(new ParallelCommand(new ParallelConfiguration()));
+        $application->addCommands([new ParallelCommand(new ParallelConfiguration())]);
 
         $command = $application->find('run');
         $commandTester = new CommandTester($command);

--- a/tests/Unit/Command/CoverageCommandTest.php
+++ b/tests/Unit/Command/CoverageCommandTest.php
@@ -50,7 +50,7 @@ class CoverageCommandTest extends BaseUnitTestCase
 
         $command = new CoverageCommand($configuration->reveal());
         $application = new Application();
-        $application->add($command);
+        $application->addCommands([$command]);
         $command = $application->find('coverage');
         $commandTester = new CommandTester($command);
 
@@ -89,7 +89,7 @@ class CoverageCommandTest extends BaseUnitTestCase
 
         $command = new CoverageCommand($configuration->reveal());
         $application = new Application();
-        $application->add($command);
+        $application->addCommands([$command]);
         $command = $application->find('coverage');
         $commandTester = new CommandTester($command);
 

--- a/tests/Unit/Command/ParallelCommandTest.php
+++ b/tests/Unit/Command/ParallelCommandTest.php
@@ -40,7 +40,7 @@ class ParallelCommandTest extends BaseUnitTestCase
 
         $command = new ParallelCommand($configuration->reveal());
         $application = new Application();
-        $application->add($command);
+        $application->addCommands([$command]);
         $command = $application->find('run');
         $commandTester = new CommandTester($command);
 


### PR DESCRIPTION
This PR increase version constraints on `symfony/*` packages to allow Symfony 8, which will be released this month.

- Related to https://github.com/infection/infection/pull/2551
- Requires https://github.com/facile-it/facile-coding-standard/pull/84