### PR TITLE
Respect ignored issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. For previou
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
-* ...
+* Suppress output for test issues that are ignored [#381](https://github.com/facile-it/paraunit/pull/381)
 
 ## [2.9.0] - 2026-04-20
 * Add coverage cache warmup [#379](https://github.com/facile-it/paraunit/pull/379)

--- a/src/Logs/JSON/LogHandler.php
+++ b/src/Logs/JSON/LogHandler.php
@@ -47,6 +47,10 @@ class LogHandler
 
     public function processLog(Process $process, LogData $log): void
     {
+        if ($log->isIgnoredByTest()) {
+            return;
+        }
+
         if ($log->status === LogStatus::Started) {
             $this->currentTest = $log->test;
             $this->startedTestCount += (int) $log->message;
@@ -76,6 +80,12 @@ class LogHandler
 
         if ($log->status === LogStatus::LogTerminated) {
             $this->handleLogEnding($process);
+
+            return;
+        }
+
+        if ($log->isIgnoredByBaseline()) {
+            $this->testResultContainer->addIgnoredByBaseline($log->status->toTestStatus());
 
             return;
         }

--- a/src/Logs/TestHook/AbstractTestHook.php
+++ b/src/Logs/TestHook/AbstractTestHook.php
@@ -39,9 +39,16 @@ abstract class AbstractTestHook
             . trim($throwable->stackTrace());
     }
 
-    final protected function write(LogStatus $status, Test $test, ?string $message): void
-    {
-        \fwrite(self::$logFile, json_encode(new LogData($status, $test, $message), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE));
+    final protected function write(
+        LogStatus $status,
+        Test $test,
+        ?string $message,
+        bool $ignoredByTest = false,
+        bool $ignoredByBaseline = false,
+    ): void {
+        $logData = new LogData($status, $test, $message, $ignoredByTest, $ignoredByBaseline);
+
+        \fwrite(self::$logFile, json_encode($logData, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE));
         \fflush(self::$logFile);
     }
 

--- a/src/Logs/TestHook/Deprecation.php
+++ b/src/Logs/TestHook/Deprecation.php
@@ -16,6 +16,12 @@ class Deprecation extends AbstractTestHook implements DeprecationTriggeredSubscr
 {
     public function notify(DeprecationTriggered $event): void
     {
-        $this->write(LogStatus::Deprecation, Test::fromPHPUnitTest($event->test()), $event->message());
+        $this->write(
+            LogStatus::Deprecation,
+            Test::fromPHPUnitTest($event->test()),
+            $event->message(),
+            $event->ignoredByTest(),
+            $event->ignoredByBaseline(),
+        );
     }
 }

--- a/src/Logs/TestHook/Notice.php
+++ b/src/Logs/TestHook/Notice.php
@@ -16,6 +16,11 @@ class Notice extends AbstractTestHook implements NoticeTriggeredSubscriber
 {
     public function notify(NoticeTriggered $event): void
     {
-        $this->write(LogStatus::Notice, Test::fromPHPUnitTest($event->test()), $event->message());
+        $this->write(
+            LogStatus::Notice,
+            Test::fromPHPUnitTest($event->test()),
+            $event->message(),
+            ignoredByBaseline: $event->ignoredByBaseline(),
+        );
     }
 }

--- a/src/Logs/TestHook/PhpDeprecation.php
+++ b/src/Logs/TestHook/PhpDeprecation.php
@@ -16,6 +16,12 @@ class PhpDeprecation extends AbstractTestHook implements PhpDeprecationTriggered
 {
     public function notify(PhpDeprecationTriggered $event): void
     {
-        $this->write(LogStatus::Deprecation, Test::fromPHPUnitTest($event->test()), $event->message());
+        $this->write(
+            LogStatus::Deprecation,
+            Test::fromPHPUnitTest($event->test()),
+            $event->message(),
+            $event->ignoredByTest(),
+            $event->ignoredByBaseline(),
+        );
     }
 }

--- a/src/Logs/TestHook/PhpNotice.php
+++ b/src/Logs/TestHook/PhpNotice.php
@@ -16,6 +16,11 @@ class PhpNotice extends AbstractTestHook implements PhpNoticeTriggeredSubscriber
 {
     public function notify(PhpNoticeTriggered $event): void
     {
-        $this->write(LogStatus::Notice, Test::fromPHPUnitTest($event->test()), $event->message());
+        $this->write(
+            LogStatus::Notice,
+            Test::fromPHPUnitTest($event->test()),
+            $event->message(),
+            ignoredByBaseline: $event->ignoredByBaseline(),
+        );
     }
 }

--- a/src/Logs/TestHook/PhpWarning.php
+++ b/src/Logs/TestHook/PhpWarning.php
@@ -16,6 +16,11 @@ class PhpWarning extends AbstractTestHook implements PhpWarningTriggeredSubscrib
 {
     public function notify(PhpWarningTriggered $event): void
     {
-        $this->write(LogStatus::WarningTriggered, Test::fromPHPUnitTest($event->test()), $event->message());
+        $this->write(
+            LogStatus::WarningTriggered,
+            Test::fromPHPUnitTest($event->test()),
+            $event->message(),
+            ignoredByBaseline: $event->ignoredByBaseline(),
+        );
     }
 }

--- a/src/Logs/TestHook/TestWarning.php
+++ b/src/Logs/TestHook/TestWarning.php
@@ -16,6 +16,11 @@ class TestWarning extends AbstractTestHook implements WarningTriggeredSubscriber
 {
     public function notify(WarningTriggered $event): void
     {
-        $this->write(LogStatus::WarningTriggered, Test::fromPHPUnitTest($event->test()), $event->message());
+        $this->write(
+            LogStatus::WarningTriggered,
+            Test::fromPHPUnitTest($event->test()),
+            $event->message(),
+            ignoredByBaseline: $event->ignoredByBaseline(),
+        );
     }
 }

--- a/src/Logs/ValueObject/LogData.php
+++ b/src/Logs/ValueObject/LogData.php
@@ -9,11 +9,29 @@ class LogData implements \JsonSerializable
     public function __construct(
         public readonly LogStatus $status,
         public readonly Test $test,
-        public readonly ?string $message
+        public readonly ?string $message,
+        private readonly ?bool $ignoredByTest = null,
+        private readonly ?bool $ignoredByBaseline = null,
     ) {}
 
+    public function isIgnoredByTest(): bool
+    {
+        return $this->ignoredByTest ?? false;
+    }
+
+    public function isIgnoredByBaseline(): bool
+    {
+        return $this->ignoredByBaseline ?? false;
+    }
+
     /**
-     * @psalm-assert array{status: string, test: string|array<mixed>, message?: string|null} $log
+     * @psalm-assert array{
+     *     status: string,
+     *     test: string|array<mixed>,
+     *     message?: string|null,
+     *     ignoredByTest: bool|null,
+     *     ignoredByBaseline: bool|null,
+     * } $log
      */
     private static function validateLogFormat(mixed $log): void
     {
@@ -21,8 +39,10 @@ class LogData implements \JsonSerializable
             throw new \InvalidArgumentException('Expecting array from log entry, got ' . get_debug_type($log));
         }
 
-        if (! isset($log['status'], $log['test'])) {
-            throw new \InvalidArgumentException('Missing fields in Paraunit logs');
+        foreach (['status', 'test', 'ignoredByTest', 'ignoredByBaseline'] as $requiredKey) {
+            if (! array_key_exists($requiredKey, $log)) {
+                throw new \InvalidArgumentException('Missing fields in Paraunit logs');
+            }
         }
 
         if (! is_string($log['status'])) {
@@ -30,6 +50,14 @@ class LogData implements \JsonSerializable
         }
 
         if (! is_string($log['message'] ?? '')) {
+            throw new \InvalidArgumentException('Invalid field message in Paraunit logs');
+        }
+
+        if (! is_null($log['ignoredByTest']) && ! is_bool($log['ignoredByTest'])) {
+            throw new \InvalidArgumentException('Invalid field message in Paraunit logs');
+        }
+
+        if (! is_null($log['ignoredByBaseline']) && ! is_bool($log['ignoredByBaseline'])) {
             throw new \InvalidArgumentException('Invalid field message in Paraunit logs');
         }
     }
@@ -44,6 +72,8 @@ class LogData implements \JsonSerializable
         $data = [
             'status' => $this->status->value,
             'test' => $this->test->jsonSerialize(),
+            'ignoredByTest' => $this->ignoredByTest,
+            'ignoredByBaseline' => $this->ignoredByBaseline,
         ];
 
         if (null !== $this->message) {
@@ -55,8 +85,12 @@ class LogData implements \JsonSerializable
         return $data;
     }
 
-    private function convertToUtf8(string $string): string
+    private function convertToUtf8(?string $string): ?string
     {
+        if ($string === null) {
+            return null;
+        }
+
         /** @psalm-suppress RiskyTruthyFalsyComparison */
         if (! \mb_detect_encoding($string, 'UTF-8', true)) {
             return \mb_convert_encoding($string, 'UTF-8') ?: '';
@@ -90,6 +124,8 @@ class LogData implements \JsonSerializable
                     LogStatus::from($log['status']),
                     $lastTest = Test::deserialize($log['test']),
                     $log['message'] ?? null,
+                    $log['ignoredByTest'] ?? null,
+                    $log['ignoredByBaseline'] ?? null,
                 );
             }
         } catch (\Throwable $e) {

--- a/src/Printer/FilesRecapPrinter.php
+++ b/src/Printer/FilesRecapPrinter.php
@@ -56,8 +56,9 @@ class FilesRecapPrinter implements EventSubscriberInterface
     private function printFileRecap(TestOutcome|TestIssue $status, OutputStyle $style): void
     {
         $filenames = $this->testResultContainer->getFileNames($status);
+        $ignored = $this->testResultContainer->getIgnoredByBaseline($status);
 
-        if ($filenames === []) {
+        if ($filenames === [] && $ignored === 0) {
             return;
         }
 
@@ -76,6 +77,16 @@ class FilesRecapPrinter implements EventSubscriberInterface
 
         foreach ($filenames as $fileName) {
             $this->output->writeln(sprintf(' <%s>%s</%s>', $style->value, $fileName, $style->value));
+        }
+
+        if ($ignored > 0) {
+            $this->output->writeln(sprintf(
+                ' <%s>(%d %s ignored by baseline)</%s>',
+                $style->value,
+                $ignored,
+                $status->getTitle(),
+                $style->value,
+            ));
         }
     }
 }

--- a/src/TestResult/TestResultContainer.php
+++ b/src/TestResult/TestResultContainer.php
@@ -17,6 +17,20 @@ class TestResultContainer
     /** @var array<value-of<TestOutcome|TestIssue>, TestResultWithMessage[]> */
     private array $testResults = [];
 
+    /** @var array<value-of<TestOutcome|TestIssue>, 0|positive-int> */
+    private array $ignoredByBaseline = [];
+
+    public function addIgnoredByBaseline(TestOutcome|TestIssue $status): void
+    {
+        $this->ignoredByBaseline[$status->value] ??= 0;
+        ++$this->ignoredByBaseline[$status->value];
+    }
+
+    public function getIgnoredByBaseline(TestOutcome|TestIssue $status): int
+    {
+        return $this->ignoredByBaseline[$status->value] ?? 0;
+    }
+
     public function addTestResult(TestResult $testResult): void
     {
         $this->addToFilenames($testResult);

--- a/tests/Unit/Logs/LogHandlerTest.php
+++ b/tests/Unit/Logs/LogHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Logs;
 
+use Paraunit\Lifecycle\TestCompleted;
 use Paraunit\Logs\JSON\LogHandler;
 use Paraunit\Logs\ValueObject\LogData;
 use Paraunit\Logs\ValueObject\LogStatus;
@@ -12,6 +13,7 @@ use Paraunit\TestResult\TestResultContainer;
 use Paraunit\TestResult\ValueObject\TestIssue;
 use Paraunit\TestResult\ValueObject\TestOutcome;
 use Paraunit\TestResult\ValueObject\TestResult;
+use Prophecy\Argument;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Tests\BaseUnitTestCase;
 use Tests\Stub\StubbedParaunitProcess;
@@ -24,7 +26,7 @@ class LogHandlerTest extends BaseUnitTestCase
         $test = new Test($process->filename);
 
         $logHandler = new LogHandler(
-            $this->prophesize(EventDispatcherInterface::class)->reveal(),
+            $this->mockEventDispatcher(null),
             $this->mockTestResultContainer($test, [TestOutcome::NoTestExecuted]),
         );
 
@@ -38,7 +40,7 @@ class LogHandlerTest extends BaseUnitTestCase
         $test = new Test($process->filename);
 
         $logHandler = new LogHandler(
-            $this->prophesize(EventDispatcherInterface::class)->reveal(),
+            $this->mockEventDispatcher(new TestCompleted($test, TestIssue::Deprecation)),
             $this->mockTestResultContainer($test, [TestOutcome::Passed, TestIssue::Deprecation])
         );
 
@@ -50,12 +52,50 @@ class LogHandlerTest extends BaseUnitTestCase
         $logHandler->processLog($process, new LogData(LogStatus::LogTerminated, $test, ''));
     }
 
+    public function testLogIgnoredByTestIsSkipped(): void
+    {
+        $process = new StubbedParaunitProcess();
+        $test = new Test($process->filename);
+
+        $logHandler = new LogHandler(
+            $this->mockEventDispatcher(new TestCompleted($test, TestOutcome::Passed)),
+            $this->mockTestResultContainer($test, [TestOutcome::Passed])
+        );
+
+        $logHandler->processLog($process, new LogData(LogStatus::Started, $test, '1'));
+        $logHandler->processLog($process, new LogData(LogStatus::Prepared, $test, ''));
+        $logHandler->processLog($process, new LogData(LogStatus::Passed, $test, ''));
+        $logHandler->processLog($process, new LogData(LogStatus::Deprecation, $test, '', true));
+        $logHandler->processLog($process, new LogData(LogStatus::Finished, $test, ''));
+        $logHandler->processLog($process, new LogData(LogStatus::LogTerminated, $test, ''));
+    }
+
+    public function testLogIgnoredByBaselineIsCounted(): void
+    {
+        $process = new StubbedParaunitProcess();
+        $test = new Test($process->filename);
+
+        $logHandler = new LogHandler(
+            $this->mockEventDispatcher(new TestCompleted($test, TestOutcome::Passed)),
+            $this->mockTestResultContainer($test, [TestOutcome::Passed], 1)
+        );
+
+        $logHandler->processLog($process, new LogData(LogStatus::Started, $test, '1'));
+        $logHandler->processLog($process, new LogData(LogStatus::Prepared, $test, ''));
+        $logHandler->processLog($process, new LogData(LogStatus::Passed, $test, ''));
+        $logHandler->processLog($process, new LogData(LogStatus::Deprecation, $test, '', ignoredByBaseline: true));
+        $logHandler->processLog($process, new LogData(LogStatus::Finished, $test, ''));
+        $logHandler->processLog($process, new LogData(LogStatus::LogTerminated, $test, ''));
+    }
+
     /**
      * @param array<TestOutcome|TestIssue> $expectedStatuses
      */
-    private function mockTestResultContainer(Test $test, array $expectedStatuses): TestResultContainer
+    private function mockTestResultContainer(Test $test, array $expectedStatuses, int $ignoredByBaseline = 0): TestResultContainer
     {
         $testResultContainer = $this->prophesize(TestResultContainer::class);
+        $testResultContainer->addIgnoredByBaseline(Argument::cetera())
+            ->shouldBeCalledTimes($ignoredByBaseline);
 
         foreach ($expectedStatuses as $expectedStatus) {
             $testResultContainer->addTestResult(new EqualsToken(new TestResult($test, $expectedStatus)))
@@ -63,5 +103,20 @@ class LogHandlerTest extends BaseUnitTestCase
         }
 
         return $testResultContainer->reveal();
+    }
+
+    private function mockEventDispatcher(?object $expectedEvent): EventDispatcherInterface
+    {
+        $eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+
+        if ($expectedEvent) {
+            $eventDispatcher->dispatch($expectedEvent)
+                ->shouldBeCalledOnce();
+        } else {
+            $eventDispatcher->dispatch()
+                ->shouldNotBeCalled();
+        }
+
+        return $eventDispatcher->reveal();
     }
 }

--- a/tests/Unit/Logs/TestHook/AbstractTestHookTestCase.php
+++ b/tests/Unit/Logs/TestHook/AbstractTestHookTestCase.php
@@ -64,32 +64,29 @@ abstract class AbstractTestHookTestCase extends BaseUnitTestCase
 
         $subscriber->notify($this->createEvent());
 
-        $logFile = $this->getRandomTempDir() . '123.json.log';
-        $this->assertFileExists($logFile);
-        $logContent = file_get_contents($logFile);
-        $this->assertNotFalse($logContent);
-
-        $logData = LogData::parse($logContent);
-        $this->assertCount(2, $logData);
-        $this->assertEquals($this->getExpectedStatus(), $logData[0]->status);
+        $deserializedlogData = $this->getDeserializedLogData();
+        $this->assertEquals($this->getExpectedStatus(), $deserializedlogData->status);
 
         if ($this->updatesLastTest()) {
-            $this->assertEquals($this->getExpectedTestObject(), $logData[0]->test);
+            $this->assertEquals($this->getExpectedTestObject(), $deserializedlogData->test);
         } else {
-            $this->assertEquals(Test::unknown(), $logData[0]->test);
+            $this->assertEquals(Test::unknown(), $deserializedlogData->test);
         }
 
         $expectedMessage = $this->getExpectedMessage();
         if (is_array($expectedMessage)) {
             $this->assertNotEmpty($expectedMessage, 'Wrong data provider, empty expected message list');
-            $this->assertNotNull($logData[0]->message, 'Missing log message');
+            $this->assertNotNull($deserializedlogData->message, 'Missing log message');
 
             foreach ($expectedMessage as $substring) {
-                $this->assertStringContainsString($substring, $logData[0]->message);
+                $this->assertStringContainsString($substring, $deserializedlogData->message);
             }
         } else {
-            $this->assertEquals($expectedMessage, $logData[0]->message);
+            $this->assertEquals($expectedMessage, $deserializedlogData->message);
         }
+
+        $this->assertFalse($deserializedlogData->isIgnoredByTest(), 'IgnoredByTest flag should be false by default');
+        $this->assertFalse($deserializedlogData->isIgnoredByBaseline(), 'IgnoredByBaseline flag should be false by default');
     }
 
     public function testLogDirNotWritable(): void
@@ -164,5 +161,18 @@ abstract class AbstractTestHookTestCase extends BaseUnitTestCase
     protected function getExpectedTestObject(): Test
     {
         return new TestMethod(static::class, 'testNotify');
+    }
+
+    protected function getDeserializedLogData(): LogData
+    {
+        $logFile = $this->getRandomTempDir() . '123.json.log';
+        $this->assertFileExists($logFile);
+        $logContent = file_get_contents($logFile);
+        $this->assertNotFalse($logContent);
+
+        $logData = LogData::parse($logContent);
+        $this->assertCount(2, $logData);
+
+        return $logData[0];
     }
 }

--- a/tests/Unit/Logs/TestHook/DeprecationTest.php
+++ b/tests/Unit/Logs/TestHook/DeprecationTest.php
@@ -16,6 +16,22 @@ use PHPUnit\Framework\Assert;
  */
 class DeprecationTest extends AbstractTestHookTestCase
 {
+    public function testIgnoredByTest(): void
+    {
+        $this->createSubscriber()->notify($this->createEvent(ignoredByTest: true));
+
+        $logData = $this->getDeserializedLogData();
+        $this->assertTrue($logData->isIgnoredByTest(), 'ignoredByTest flag should be true');
+    }
+
+    public function testIgnoredByBaseline(): void
+    {
+        $this->createSubscriber()->notify($this->createEvent(ignoredByBaseline: true));
+
+        $logData = $this->getDeserializedLogData();
+        $this->assertTrue($logData->isIgnoredByBaseline(), 'ignoredByBaseline flag should be true');
+    }
+
     protected function createSubscriber(): Deprecation
     {
         return new Deprecation();
@@ -26,7 +42,7 @@ class DeprecationTest extends AbstractTestHookTestCase
         return LogStatus::Deprecation;
     }
 
-    protected function createEvent(): DeprecationTriggered
+    protected function createEvent(bool $ignoredByBaseline = false, bool $ignoredByTest = false): DeprecationTriggered
     {
         $args = [
             $this->createTelemetryInfo(),
@@ -35,8 +51,8 @@ class DeprecationTest extends AbstractTestHookTestCase
             'testFile.php',
             123,
             false,
-            false,
-            false,
+            $ignoredByBaseline,
+            $ignoredByTest,
         ];
 
         if (class_exists(IssueTrigger::class)) {

--- a/tests/Unit/Logs/TestHook/NoticeTest.php
+++ b/tests/Unit/Logs/TestHook/NoticeTest.php
@@ -8,11 +8,21 @@ use Paraunit\Logs\TestHook\Notice;
 use Paraunit\Logs\ValueObject\LogStatus;
 use PHPUnit\Event\Test\NoticeTriggered;
 
+use const false;
+
 /**
  * @template-extends AbstractTestHookTestCase<Notice, NoticeTriggered>
  */
 class NoticeTest extends AbstractTestHookTestCase
 {
+    public function testIgnoredByBaseline(): void
+    {
+        $this->createSubscriber()->notify($this->createEvent(ignoredByBaseline: true));
+
+        $logData = $this->getDeserializedLogData();
+        $this->assertTrue($logData->isIgnoredByBaseline(), 'ignoredByBaseline flag should be true');
+    }
+
     protected function createSubscriber(): Notice
     {
         return new Notice();
@@ -23,7 +33,7 @@ class NoticeTest extends AbstractTestHookTestCase
         return LogStatus::Notice;
     }
 
-    protected function createEvent(): NoticeTriggered
+    protected function createEvent(bool $ignoredByBaseline = false): NoticeTriggered
     {
         return new NoticeTriggered(
             $this->createTelemetryInfo(),
@@ -32,7 +42,7 @@ class NoticeTest extends AbstractTestHookTestCase
             'testFile.php',
             123,
             false,
-            false,
+            $ignoredByBaseline,
         );
     }
 

--- a/tests/Unit/Logs/TestHook/PhpDeprecationTest.php
+++ b/tests/Unit/Logs/TestHook/PhpDeprecationTest.php
@@ -15,6 +15,22 @@ use PHPUnit\Event\Test\PhpDeprecationTriggered;
  */
 class PhpDeprecationTest extends AbstractTestHookTestCase
 {
+    public function testIgnoredByTest(): void
+    {
+        $this->createSubscriber()->notify($this->createEvent(ignoredByTest: true));
+
+        $logData = $this->getDeserializedLogData();
+        $this->assertTrue($logData->isIgnoredByTest(), 'ignoredByTest flag should be true');
+    }
+
+    public function testIgnoredByBaseline(): void
+    {
+        $this->createSubscriber()->notify($this->createEvent(ignoredByBaseline: true));
+
+        $logData = $this->getDeserializedLogData();
+        $this->assertTrue($logData->isIgnoredByBaseline(), 'ignoredByBaseline flag should be true');
+    }
+
     protected function createSubscriber(): PhpDeprecation
     {
         return new PhpDeprecation();
@@ -25,7 +41,7 @@ class PhpDeprecationTest extends AbstractTestHookTestCase
         return LogStatus::Deprecation;
     }
 
-    protected function createEvent(): PhpDeprecationTriggered
+    protected function createEvent(bool $ignoredByBaseline = false, bool $ignoredByTest = false): PhpDeprecationTriggered
     {
         $args = [
             $this->createTelemetryInfo(),
@@ -34,8 +50,8 @@ class PhpDeprecationTest extends AbstractTestHookTestCase
             'testFile.php',
             123,
             false,
-            false,
-            false,
+            $ignoredByBaseline,
+            $ignoredByTest,
         ];
 
         if (class_exists(IssueTrigger::class)) {

--- a/tests/Unit/Logs/TestHook/PhpNoticeTest.php
+++ b/tests/Unit/Logs/TestHook/PhpNoticeTest.php
@@ -13,6 +13,14 @@ use PHPUnit\Event\Test\PhpNoticeTriggered;
  */
 class PhpNoticeTest extends AbstractTestHookTestCase
 {
+    public function testIgnoredByBaseline(): void
+    {
+        $this->createSubscriber()->notify($this->createEvent(ignoredByBaseline: true));
+
+        $logData = $this->getDeserializedLogData();
+        $this->assertTrue($logData->isIgnoredByBaseline(), 'ignoredByBaseline flag should be true');
+    }
+
     protected function createSubscriber(): PhpNotice
     {
         return new PhpNotice();
@@ -23,7 +31,7 @@ class PhpNoticeTest extends AbstractTestHookTestCase
         return LogStatus::Notice;
     }
 
-    protected function createEvent(): PhpNoticeTriggered
+    protected function createEvent(bool $ignoredByBaseline = false): PhpNoticeTriggered
     {
         return new PhpNoticeTriggered(
             $this->createTelemetryInfo(),
@@ -32,7 +40,7 @@ class PhpNoticeTest extends AbstractTestHookTestCase
             'testFile.php',
             123,
             false,
-            false,
+            $ignoredByBaseline,
         );
     }
 

--- a/tests/Unit/Logs/TestHook/PhpWarningTest.php
+++ b/tests/Unit/Logs/TestHook/PhpWarningTest.php
@@ -13,6 +13,14 @@ use PHPUnit\Event\Test\PhpWarningTriggered;
  */
 class PhpWarningTest extends AbstractTestHookTestCase
 {
+    public function testIgnoredByBaseline(): void
+    {
+        $this->createSubscriber()->notify($this->createEvent(ignoredByBaseline: true));
+
+        $logData = $this->getDeserializedLogData();
+        $this->assertTrue($logData->isIgnoredByBaseline(), 'ignoredByBaseline flag should be true');
+    }
+
     protected function createSubscriber(): PhpWarning
     {
         return new PhpWarning();
@@ -23,7 +31,7 @@ class PhpWarningTest extends AbstractTestHookTestCase
         return LogStatus::WarningTriggered;
     }
 
-    protected function createEvent(): PhpWarningTriggered
+    protected function createEvent(bool $ignoredByBaseline = false): PhpWarningTriggered
     {
         return new PhpWarningTriggered(
             $this->createTelemetryInfo(),
@@ -32,7 +40,7 @@ class PhpWarningTest extends AbstractTestHookTestCase
             __FILE__,
             1,
             false,
-            false,
+            $ignoredByBaseline,
         );
     }
 

--- a/tests/Unit/Logs/TestHook/TestWarningTest.php
+++ b/tests/Unit/Logs/TestHook/TestWarningTest.php
@@ -13,6 +13,14 @@ use PHPUnit\Event\Test\WarningTriggered;
  */
 class TestWarningTest extends AbstractTestHookTestCase
 {
+    public function testIgnoredByBaseline(): void
+    {
+        $this->createSubscriber()->notify($this->createEvent(ignoredByBaseline: true));
+
+        $logData = $this->getDeserializedLogData();
+        $this->assertTrue($logData->isIgnoredByBaseline(), 'ignoredByBaseline flag should be true');
+    }
+
     protected function createSubscriber(): TestWarning
     {
         return new TestWarning();
@@ -23,7 +31,7 @@ class TestWarningTest extends AbstractTestHookTestCase
         return LogStatus::WarningTriggered;
     }
 
-    protected function createEvent(): WarningTriggered
+    protected function createEvent(bool $ignoredByBaseline = false): WarningTriggered
     {
         return new WarningTriggered(
             $this->createTelemetryInfo(),
@@ -32,7 +40,7 @@ class TestWarningTest extends AbstractTestHookTestCase
             __FILE__,
             1,
             false,
-            false,
+            $ignoredByBaseline,
         );
     }
 

--- a/tests/Unit/Logs/ValueObject/LogDataTest.php
+++ b/tests/Unit/Logs/ValueObject/LogDataTest.php
@@ -8,6 +8,7 @@ use Paraunit\Logs\ValueObject\LogData;
 use Paraunit\Logs\ValueObject\LogStatus;
 use Paraunit\Logs\ValueObject\Test;
 use Paraunit\Logs\ValueObject\TestMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -81,14 +82,39 @@ class LogDataTest extends TestCase
         $this->assertFalse($unserialized[0]->isIgnoredByBaseline());
     }
 
-    public function testSerializationError(): void
+    #[DataProvider('invalidSerializedDataProvider')]
+    public function testSerializationError(array $invalidSerializedData): void
     {
-        $parsedResult = LogData::parse('{}');
+        $parsedResult = LogData::parse(json_encode($invalidSerializedData, JSON_THROW_ON_ERROR));
 
         $this->assertCount(2, $parsedResult);
         $this->assertEquals(LogStatus::Unknown, $parsedResult[0]->status);
         $this->assertEquals(Test::unknown(), $parsedResult[0]->test);
         $this->assertIsString($parsedResult[0]->message);
         $this->assertStringStartsWith('Error while parsing Paraunit logs: ', $parsedResult[0]->message);
+    }
+
+    /**
+     * @return \Generator<array{array<string, mixed>}>
+     */
+    public static function invalidSerializedDataProvider(): \Generator
+    {
+        yield 'empty array' => [[]];
+
+        $validLogData = (new LogData(LogStatus::Passed, new Test('Foo'), 'Test message'))->jsonSerialize();
+
+        foreach (['status', 'test', 'ignoredByTest', 'ignoredByBaseline'] as $requiredKey) {
+            $invalidLogData = $validLogData;
+            unset($invalidLogData[$requiredKey]);
+            yield 'without ' . $requiredKey => [$invalidLogData];
+
+            $invalidLogData = $validLogData;
+            $invalidLogData[$requiredKey] = 123.456;
+            yield 'invalid format for ' . $requiredKey => [$invalidLogData];
+        }
+
+        $invalidLogData = $validLogData;
+        $invalidLogData['message'] = 123.456;
+        yield 'invalid format for message' => [$invalidLogData];
     }
 }

--- a/tests/Unit/Logs/ValueObject/LogDataTest.php
+++ b/tests/Unit/Logs/ValueObject/LogDataTest.php
@@ -70,6 +70,17 @@ class LogDataTest extends TestCase
         $this->assertSame('Foo::bar', $parsedResult[0]->test->name);
     }
 
+    public function testSerializeWithNoAdditionalParams(): void
+    {
+        $logData = new LogData(LogStatus::Passed, new Test('Foo'), 'Test message');
+
+        $unserialized = LogData::parse(json_encode($logData, JSON_THROW_ON_ERROR));
+
+        $this->assertCount(2, $unserialized);
+        $this->assertFalse($unserialized[0]->isIgnoredByTest());
+        $this->assertFalse($unserialized[0]->isIgnoredByBaseline());
+    }
+
     public function testSerializationError(): void
     {
         $parsedResult = LogData::parse('{}');

--- a/tests/Unit/Logs/ValueObject/LogDataTest.php
+++ b/tests/Unit/Logs/ValueObject/LogDataTest.php
@@ -82,6 +82,9 @@ class LogDataTest extends TestCase
         $this->assertFalse($unserialized[0]->isIgnoredByBaseline());
     }
 
+    /**
+     * @param array<string, mixed> $invalidSerializedData
+     */
     #[DataProvider('invalidSerializedDataProvider')]
     public function testSerializationError(array $invalidSerializedData): void
     {

--- a/tests/Unit/Printer/FilesRecapPrinterTest.php
+++ b/tests/Unit/Printer/FilesRecapPrinterTest.php
@@ -8,6 +8,7 @@ use Paraunit\Configuration\ChunkSize;
 use Paraunit\Logs\ValueObject\TestMethod;
 use Paraunit\Printer\FilesRecapPrinter;
 use Paraunit\TestResult\TestResultContainer;
+use Paraunit\TestResult\ValueObject\TestIssue;
 use Paraunit\TestResult\ValueObject\TestOutcome;
 use Paraunit\TestResult\ValueObject\TestResult;
 use Prophecy\Argument;
@@ -16,6 +17,48 @@ use Tests\Stub\UnformattedOutputStub;
 
 class FilesRecapPrinterTest extends BaseUnitTestCase
 {
+    public function testOnEngineEndDoesNotPrintCountOfIgnoredIssuesIfThereAreNone(): void
+    {
+        $output = new UnformattedOutputStub();
+        $testResultContainer = $this->prophesize(TestResultContainer::class);
+        $testResultContainer->getTestResults(Argument::cetera())
+            ->willReturn([]);
+        $testResultContainer->getFileNames(Argument::cetera())
+            ->willReturn([]);
+        $testResultContainer->getIgnoredByBaseline(Argument::cetera())
+            ->willReturn(0);
+        $chunkSize = $this->prophesize(ChunkSize::class);
+        $chunkSize->isChunked()->willReturn(false);
+
+        $printer = new FilesRecapPrinter($output, $testResultContainer->reveal(), $chunkSize->reveal());
+
+        $printer->onEngineEnd();
+
+        $this->assertStringNotContainsStringIgnoringCase('ignored by baseline', $output->getOutput());
+    }
+
+    public function testOnEngineEndPrintsCountOfIgnoredIssues(): void
+    {
+        $output = new UnformattedOutputStub();
+        $testResultContainer = $this->prophesize(TestResultContainer::class);
+        $testResultContainer->getTestResults(Argument::cetera())
+            ->willReturn([]);
+        $testResultContainer->getFileNames(Argument::cetera())
+            ->willReturn([]);
+        $testResultContainer->getIgnoredByBaseline(Argument::cetera())
+            ->willReturn(0);
+        $testResultContainer->getIgnoredByBaseline(TestIssue::Deprecation)
+            ->willReturn(3);
+        $chunkSize = $this->prophesize(ChunkSize::class);
+        $chunkSize->isChunked()->willReturn(false);
+
+        $printer = new FilesRecapPrinter($output, $testResultContainer->reveal(), $chunkSize->reveal());
+
+        $printer->onEngineEnd();
+
+        $this->assertStringContainsString('3 deprecations ignored by baseline', $output->getOutput());
+    }
+
     public function testOnEngineEndPrintsTheRightChunkedCountSummary(): void
     {
         $output = new UnformattedOutputStub();
@@ -25,6 +68,8 @@ class FilesRecapPrinterTest extends BaseUnitTestCase
             ->willReturn(true);
 
         $testResultContainer = $this->prophesize(TestResultContainer::class);
+        $testResultContainer->getIgnoredByBaseline(Argument::cetera())
+            ->willReturn(0);
         $testResultContainer->getTestResults(Argument::cetera())
             ->willReturn([]);
         $testResultContainer->getTestResults(TestOutcome::Failure)
@@ -44,5 +89,6 @@ class FilesRecapPrinterTest extends BaseUnitTestCase
         $printer->onEngineEnd();
 
         $this->assertStringContainsString('1 chunks with FAILURES:', $output->getOutput());
+        $this->assertStringNotContainsStringIgnoringCase('ignored by baseline', $output->getOutput());
     }
 }


### PR DESCRIPTION
This fixes #380, but in a broader sense: it handles all kind of ignored issues, both by baseline and in-test attributes, whenever declared by PHPUnit's events.

@keradus can you test it out on your case?