### PR TITLE
Add the new compatible versions to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can use Paraunit with many versions of PHPUnit or Symfony, following this co
 
 | Paraunit version | Compatible PHPUnit Version | Compatible Symfony Version |
 |------------------|----------------------------|----------------------------|
-| 2.8              | 10.5.4+, 11+, 12+, 13+     | 4.4, 5, 6, 7, 8            |
+| 2.8              | 10.5.4+, 11+, 12+, 13.0    | 4.4, 5, 6, 7, 8            |
 | 2.7.1            | 10.5.4+, 11+, 12+          | 4.4, 5, 6, 7, 8            |
 | 2.5              | 10.5.4+, 11+, 12+          | 4.4, 5, 6, 7               |
 | 2.3              | 10.5.4+, 11+               | 4.4, 5, 6, 7               |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You can use Paraunit with many versions of PHPUnit or Symfony, following this co
 
 | Paraunit version | Compatible PHPUnit Version | Compatible Symfony Version |
 |------------------|----------------------------|----------------------------|
+| 2.8              | 10.5.4+, 11+, 12+, 13+     | 4.4, 5, 6, 7, 8            |
+| 2.7.1            | 10.5.4+, 11+, 12+          | 4.4, 5, 6, 7, 8            |
 | 2.5              | 10.5.4+, 11+, 12+          | 4.4, 5, 6, 7               |
 | 2.3              | 10.5.4+, 11+               | 4.4, 5, 6, 7               |
 | 2.0              | 10+                        | 4.4, 5, 6, 7               |


### PR DESCRIPTION
Support for PHPunit 13 and Symfony 8 where not in the list but exist in newer releases.

I used the information from the releases to add them to the table.

The information on https://engineering.facile.it/paraunit/ also doesn't contains the newer releases but I don't know how that is handled 😃 